### PR TITLE
feat: complete one approvals for multiple same chain actions

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -34,8 +34,8 @@ libs = ["lib"]
 fs_permissions = [{ access = "read-write", path = "./script/" }]
 
 [profile.coverage]
-fuzz = { runs = 1, max_test_rejects = 350_000 }    
-invariant = { runs = 5_000 }         
+fuzz = { runs = 1, max_test_rejects = 350_000 }
+invariant = { runs = 5_000 }
 
 [rpc_endpoints]
 ethereum = "${ETHEREUM_RPC_URL}"

--- a/src/crosschain-data/extensions/CoreStateRegistry.sol
+++ b/src/crosschain-data/extensions/CoreStateRegistry.sol
@@ -305,9 +305,7 @@ contract CoreStateRegistry is LiquidityHandler, BaseStateRegistry, ICoreStateReg
                 liqData_[v.i].token,
                 IBridgeValidator(v.bridgeValidator).decodeAmountIn(liqData_[v.i].txData),
                 address(this),
-                liqData_[v.i].nativeAmount,
-                liqData_[v.i].permit2data,
-                superRegistry.PERMIT2()
+                liqData_[v.i].nativeAmount
             );
 
             unchecked {

--- a/src/crosschain-data/utils/PayloadHelper.sol
+++ b/src/crosschain-data/utils/PayloadHelper.sol
@@ -56,7 +56,6 @@ contract PayloadHelper is IPayloadHelper {
         uint256[] liqDataAmountsIn;
         uint256[] liqDataAmountsOut;
         uint256[] liqDataNativeAmounts;
-        bytes[] permit2datas;
         InitMultiVaultData imvd;
         InitSingleVaultData isvd;
         uint256 i;
@@ -173,8 +172,7 @@ contract PayloadHelper is IPayloadHelper {
             uint64[] memory liqDstChainIds,
             uint256[] memory amountsIn,
             uint256[] memory amountsOut,
-            uint256[] memory nativeAmounts,
-            bytes[] memory permit2datas
+            uint256[] memory nativeAmounts
         )
     {
         DecodeDstPayloadLiqDataInternalVars memory v;
@@ -191,7 +189,6 @@ contract PayloadHelper is IPayloadHelper {
             v.liqDataAmountsIn = new uint256[](v.imvd.liqData.length);
             v.liqDataAmountsOut = new uint256[](v.imvd.liqData.length);
             v.liqDataNativeAmounts = new uint256[](v.imvd.liqData.length);
-            v.permit2datas = new bytes[](v.imvd.liqData.length);
 
             uint256 len = v.imvd.liqData.length;
 
@@ -207,7 +204,6 @@ contract PayloadHelper is IPayloadHelper {
                 v.liqDataAmountsOut[v.i] = IBridgeValidator(superRegistry.getBridgeValidator(v.bridgeIds[v.i]))
                     .decodeMinAmountOut(v.txDatas[v.i]);
                 v.liqDataNativeAmounts[v.i] = v.imvd.liqData[v.i].nativeAmount;
-                v.permit2datas[v.i] = v.imvd.liqData[v.i].permit2data;
 
                 unchecked {
                     ++v.i;
@@ -238,9 +234,6 @@ contract PayloadHelper is IPayloadHelper {
 
             v.liqDataNativeAmounts = new uint256[](1);
             v.liqDataNativeAmounts[0] = v.isvd.liqData.nativeAmount;
-
-            v.permit2datas = new bytes[](1);
-            v.permit2datas[0] = v.isvd.liqData.permit2data;
         }
 
         return (
@@ -250,8 +243,7 @@ contract PayloadHelper is IPayloadHelper {
             v.liqDataChainIds,
             v.liqDataAmountsIn,
             v.liqDataAmountsOut,
-            v.liqDataNativeAmounts,
-            v.permit2datas
+            v.liqDataNativeAmounts
         );
     }
 

--- a/src/crosschain-liquidity/LiquidityHandler.sol
+++ b/src/crosschain-liquidity/LiquidityHandler.sol
@@ -21,19 +21,15 @@ abstract contract LiquidityHandler {
     /// @param txData_ liquidity bridge data
     /// @param token_ Token caller deposits into superform
     /// @param amount_ Amount of tokens to deposit
-    /// @param owner_ Owner of tokens
+    /// @param srcSender_ Owner of tokens
     /// @param nativeAmount_ msg.value or msg.value + native tokens
-    /// @param permit2Data_ abi.encode of nonce, deadline & signature for the amounts being transfered
-    /// @param permit2_ Permit2 address
     function dispatchTokens(
         address bridge_,
         bytes memory txData_,
         address token_,
         uint256 amount_,
-        address owner_,
-        uint256 nativeAmount_,
-        bytes memory permit2Data_,
-        address permit2_
+        address srcSender_,
+        uint256 nativeAmount_
     )
         internal
         virtual
@@ -41,37 +37,8 @@ abstract contract LiquidityHandler {
         if (token_ != NATIVE) {
             IERC20 token = IERC20(token_);
 
-            /// @dev only for deposits, otherwise amount already in contract
-            if (owner_ != address(this)) {
-                if (permit2Data_.length == 0) {
-                    token.safeTransferFrom(owner_, address(this), amount_);
-                } else {
-                    (uint256 nonce, uint256 deadline, bytes memory signature) =
-                        abi.decode(permit2Data_, (uint256, uint256, bytes));
-
-                    IPermit2(permit2_).permitTransferFrom(
-                        // The permit message.
-                        IPermit2.PermitTransferFrom({
-                            permitted: IPermit2.TokenPermissions({ token: token, amount: amount_ }),
-                            nonce: nonce,
-                            deadline: deadline
-                        }),
-                        // The transfer recipient and amount.
-                        IPermit2.SignatureTransferDetails({ to: address(this), requestedAmount: amount_ }),
-                        // The owner of the tokens, which must also be
-                        // the signer of the message, otherwise this call
-                        // will fail.
-                        owner_,
-                        // The packed signature that was the result of signing
-                        // the EIP712 hash of `permit`.
-                        signature
-                    );
-                }
-            }
-            /// @dev approve bridge to spend tokens
-            token.safeIncreaseAllowance(bridge_, amount_);
-
             /// @dev call bridge with txData. Native amount here just contains liquidity bridge fees (if needed)
+            token.safeIncreaseAllowance(bridge_, amount_);
             unchecked {
                 (bool success,) = payable(bridge_).call{ value: nativeAmount_ }(txData_);
                 if (!success) revert Error.FAILED_TO_EXECUTE_TXDATA();

--- a/src/forms/ERC4626FormImplementation.sol
+++ b/src/forms/ERC4626FormImplementation.sol
@@ -153,10 +153,7 @@ abstract contract ERC4626FormImplementation is BaseForm, LiquidityHandler {
                 IBridgeValidator(vars.bridgeValidator).decodeAmountIn(singleVaultData_.liqData.txData),
                 address(this),
                 /// tokens are already moved in above step
-                singleVaultData_.liqData.nativeAmount,
-                bytes(""),
-                /// permit2 is useless here since the tokens are already available
-                address(0)
+                singleVaultData_.liqData.nativeAmount
             );
         }
 
@@ -236,9 +233,7 @@ abstract contract ERC4626FormImplementation is BaseForm, LiquidityHandler {
                 singleVaultData_.liqData.token,
                 v.amount,
                 address(this),
-                singleVaultData_.liqData.nativeAmount,
-                "",
-                superRegistry.PERMIT2()
+                singleVaultData_.liqData.nativeAmount
             );
         }
     }
@@ -334,9 +329,7 @@ abstract contract ERC4626FormImplementation is BaseForm, LiquidityHandler {
                 singleVaultData_.liqData.token,
                 dstAmount,
                 address(this),
-                singleVaultData_.liqData.nativeAmount,
-                "",
-                superRegistry.PERMIT2()
+                singleVaultData_.liqData.nativeAmount
             );
         }
 

--- a/src/forms/ERC4626TimelockForm.sol
+++ b/src/forms/ERC4626TimelockForm.sol
@@ -103,10 +103,7 @@ contract ERC4626TimelockForm is ERC4626FormImplementation {
                 vars.liqData.token,
                 vars.amount,
                 address(this),
-                vars.liqData.nativeAmount,
-                /// @dev be careful over here
-                "",
-                superRegistry.PERMIT2()
+                vars.liqData.nativeAmount
             );
         }
     }

--- a/src/interfaces/IPayloadHelper.sol
+++ b/src/interfaces/IPayloadHelper.sol
@@ -41,7 +41,6 @@ interface IPayloadHelper {
     /// @return amountsIn are the from amounts to the liquidity bridge
     /// @return amountsOut are the minimum amounts to be bridged through the liquidity bridge
     /// @return nativeAmounts is the native amounts to be used in the liqData
-    /// @return permit2datas is the permit2 datas to be used in the liqData
     function decodeCoreStateRegistryPayloadLiqData(uint256 dstPayloadId_)
         external
         view
@@ -52,8 +51,7 @@ interface IPayloadHelper {
             uint64[] memory liqDstChainIds,
             uint256[] memory amountsIn,
             uint256[] memory amountsOut,
-            uint256[] memory nativeAmounts,
-            bytes[] memory permit2datas
+            uint256[] memory nativeAmounts
         );
 
     /// @dev reads the payload header from a state syncer and decodes it.

--- a/src/payments/PayMaster.sol
+++ b/src/payments/PayMaster.sol
@@ -128,9 +128,7 @@ contract PayMaster is IPayMaster, LiquidityHandler {
             liqRequest_.token,
             IBridgeValidator(bridgeValidator).decodeAmountIn(liqRequest_.txData),
             msg.sender,
-            liqRequest_.nativeAmount,
-            liqRequest_.permit2data,
-            superRegistry.PERMIT2()
+            liqRequest_.nativeAmount
         );
     }
 }

--- a/src/types/DataTypes.sol
+++ b/src/types/DataTypes.sol
@@ -32,7 +32,8 @@ struct MultiVaultSFData {
     uint256[] superformIds;
     uint256[] amounts;
     uint256[] maxSlippages;
-    LiqRequest[] liqRequests; // if length = 1; amount = sum(amounts)| else  amounts must match the amounts being sent
+    LiqRequest[] liqRequests; // if length = 1; amount = sum(amounts) | else  amounts must match the amounts being sent
+    bytes permit2data;
     bytes extraFormData; // extraFormData
 }
 
@@ -43,6 +44,7 @@ struct SingleVaultSFData {
     uint256 amount;
     uint256 maxSlippage;
     LiqRequest liqRequest; // if length = 1; amount = sum(amounts)| else  amounts must match the amounts being sent
+    bytes permit2data;
     bytes extraFormData; // extraFormData
 }
 

--- a/src/types/LiquidityTypes.sol
+++ b/src/types/LiquidityTypes.sol
@@ -14,5 +14,4 @@ struct LiqRequest {
     uint64 liqDstChainId;
     /// @dev currently this amount is used as msg.value in the txData call.
     uint256 nativeAmount;
-    bytes permit2data;
 }

--- a/src/utils/Error.sol
+++ b/src/utils/Error.sol
@@ -45,6 +45,9 @@ library Error {
     /// @dev thrown if the broadcast payload is invalid
     error INVALID_BROADCAST_PAYLOAD();
 
+    /// @dev thrown if the underlying collateral mismatches
+    error INVALID_DEPOSIT_TOKEN();
+
     /// @dev thrown when msg.sender is not two step state registry
     error NOT_TWO_STEP_STATE_REGISTRY();
 

--- a/test/mocks/InterfaceNotSupported/ERC4626ImplementationInterfaceNotSupported.sol
+++ b/test/mocks/InterfaceNotSupported/ERC4626ImplementationInterfaceNotSupported.sol
@@ -116,41 +116,20 @@ abstract contract ERC4626FormImplementationInterfaceNotSupported is BaseForm, Li
 
         IERC20 token = IERC20(singleVaultData_.liqData.token);
 
+        if (address(token) != NATIVE) {
+            /// @dev handles the collateral token transfers.
+            if (token.allowance(msg.sender, address(this)) < singleVaultData_.amount) {
+                revert Error.DIRECT_DEPOSIT_INSUFFICIENT_ALLOWANCE();
+            }
+
+            /// @dev transfers input token, which is the same as vault asset, to the form
+            token.safeTransferFrom(msg.sender, address(this), singleVaultData_.amount);
+        }
+
         /// @dev if we don't have txData (no swap) then the full amount in the stateReq is used
         /// @dev non empty txData means there is a swap needed before depositing (input asset not the same as vault
         /// asset)
-        if (!(singleVaultData_.liqData.txData.length > 0)) {
-            /// @dev handles the collateral token transfers.
-            /// @dev if the input asset was approved with permit2
-            if (!(singleVaultData_.liqData.permit2data.length > 0)) {
-                if (token.allowance(srcSender_, address(this)) < singleVaultData_.amount) {
-                    revert Error.DIRECT_DEPOSIT_INSUFFICIENT_ALLOWANCE();
-                }
-                /// @dev transfers input token, which is the same as vault asset, to the form
-                token.safeTransferFrom(srcSender_, address(this), singleVaultData_.amount);
-            } else {
-                (vars.nonce, vars.deadline, vars.signature) =
-                    abi.decode(singleVaultData_.liqData.permit2data, (uint256, uint256, bytes));
-                /// @dev does a permit2 transfer to this contract
-                IPermit2(superRegistry.PERMIT2()).permitTransferFrom(
-                    // The permit message.
-                    IPermit2.PermitTransferFrom({
-                        permitted: IPermit2.TokenPermissions(token, singleVaultData_.amount),
-                        nonce: vars.nonce,
-                        deadline: vars.deadline
-                    }),
-                    // The transfer recipient and amount.
-                    IPermit2.SignatureTransferDetails({ to: address(this), requestedAmount: singleVaultData_.amount }),
-                    // The owner of the tokens, which must also be
-                    // the signer of the message, otherwise this call
-                    // will fail.
-                    srcSender_,
-                    // The packed signature that was the result of signing
-                    // the EIP712 hash of `permit`.
-                    vars.signature
-                );
-            }
-        } else {
+        if (singleVaultData_.liqData.txData.length > 0) {
             vars.bridgeValidator = superRegistry.getBridgeValidator(singleVaultData_.liqData.bridgeId);
 
             /// @dev in this case, a swap is needed, first the txData is validated and then the final asset is obtained
@@ -163,7 +142,7 @@ abstract contract ERC4626FormImplementationInterfaceNotSupported is BaseForm, Li
                 singleVaultData_.liqData.liqDstChainId,
                 true,
                 address(this),
-                srcSender_,
+                msg.sender,
                 address(token)
             );
 
@@ -172,10 +151,9 @@ abstract contract ERC4626FormImplementationInterfaceNotSupported is BaseForm, Li
                 singleVaultData_.liqData.txData,
                 address(token),
                 IBridgeValidator(vars.bridgeValidator).decodeAmountIn(singleVaultData_.liqData.txData),
-                srcSender_,
-                singleVaultData_.liqData.nativeAmount,
-                singleVaultData_.liqData.permit2data,
-                superRegistry.PERMIT2()
+                address(this),
+                /// tokens are already moved in above step
+                singleVaultData_.liqData.nativeAmount
             );
         }
 
@@ -255,9 +233,7 @@ abstract contract ERC4626FormImplementationInterfaceNotSupported is BaseForm, Li
                 singleVaultData_.liqData.token,
                 v.amount,
                 address(this),
-                singleVaultData_.liqData.nativeAmount,
-                "",
-                superRegistry.PERMIT2()
+                singleVaultData_.liqData.nativeAmount
             );
         }
     }
@@ -353,9 +329,7 @@ abstract contract ERC4626FormImplementationInterfaceNotSupported is BaseForm, Li
                 singleVaultData_.liqData.token,
                 dstAmount,
                 address(this),
-                singleVaultData_.liqData.nativeAmount,
-                "",
-                superRegistry.PERMIT2()
+                singleVaultData_.liqData.nativeAmount
             );
         }
 

--- a/test/unit/crosschain-data/extensions/CoreStateRegistry.t.sol
+++ b/test/unit/crosschain-data/extensions/CoreStateRegistry.t.sol
@@ -296,7 +296,8 @@ contract CoreStateRegistryTest is ProtocolActions {
             superformId,
             1e18,
             100,
-            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), AVAX, 0, bytes("")),
+            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), AVAX, 0),
+            bytes(""),
             bytes("")
         );
         /// @dev approves before call
@@ -336,7 +337,7 @@ contract CoreStateRegistryTest is ProtocolActions {
         SuperPositions(getContract(ETH, "SuperPositions")).mintSingle(deployer, superformId, 1e18);
 
         SingleVaultSFData memory data = SingleVaultSFData(
-            superformId, 1e18, 100, LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ETH, 0, bytes("")), bytes("")
+            superformId, 1e18, 100, LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ETH, 0), bytes(""), bytes("")
         );
 
         vm.recordLogs();
@@ -395,12 +396,11 @@ contract CoreStateRegistryTest is ProtocolActions {
             0
         );
 
-        liqReqArr[0] =
-            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), AVAX, 0, bytes(""));
+        liqReqArr[0] = LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), AVAX, 0);
         liqReqArr[1] = liqReqArr[0];
 
         MultiVaultSFData memory data =
-            MultiVaultSFData(superformIds, uint256MemArr, uint256MemArr, liqReqArr, bytes(""));
+            MultiVaultSFData(superformIds, uint256MemArr, uint256MemArr, liqReqArr, bytes(""), bytes(""));
         /// @dev approves before call
         MockERC20(getContract(ETH, "USDT")).approve(superformRouter, 1e18);
 
@@ -459,12 +459,11 @@ contract CoreStateRegistryTest is ProtocolActions {
             0
         );
 
-        liqReqArr[0] =
-            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), AVAX, 0, bytes(""));
+        liqReqArr[0] = LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), AVAX, 0);
         liqReqArr[1] = liqReqArr[0];
 
         MultiVaultSFData memory data =
-            MultiVaultSFData(superformIds, uint256MemArr, uint256MemArr, liqReqArr, bytes(""));
+            MultiVaultSFData(superformIds, uint256MemArr, uint256MemArr, liqReqArr, bytes(""), bytes(""));
         /// @dev approves before call
         MockERC20(getContract(ETH, "USDT")).approve(superformRouter, 1e18);
 
@@ -496,14 +495,15 @@ contract CoreStateRegistryTest is ProtocolActions {
         amountArr[1] = 1e18;
 
         LiqRequest[] memory liqReqArr = new LiqRequest[](2);
-        liqReqArr[0] = LiqRequest(1, bytes(""), getContract(AVAX, "USDT"), ETH, 0, bytes(""));
+        liqReqArr[0] = LiqRequest(1, bytes(""), getContract(AVAX, "USDT"), ETH, 0);
         liqReqArr[1] = liqReqArr[0];
 
         uint256[] memory maxSlippages = new uint256[](2);
         maxSlippages[0] = 1000;
         maxSlippages[1] = 1000;
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amountArr, maxSlippages, liqReqArr, bytes(""));
+        MultiVaultSFData memory data =
+            MultiVaultSFData(superformIds, amountArr, maxSlippages, liqReqArr, bytes(""), bytes(""));
 
         vm.recordLogs();
         vm.prank(deployer);

--- a/test/unit/crosschain-data/extensions/TwoStepsFormStateRegistry.t.sol
+++ b/test/unit/crosschain-data/extensions/TwoStepsFormStateRegistry.t.sol
@@ -47,7 +47,7 @@ contract TwoStepsStateRegistryTest is ProtocolActions {
                 superformId,
                 420,
                 0,
-                LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ETH, 0, bytes("")),
+                LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ETH, 0),
                 bytes("")
             )
         );
@@ -79,7 +79,7 @@ contract TwoStepsStateRegistryTest is ProtocolActions {
                 1000,
                 /// @dev note txData (2nd arg) is empty and token (3rd arg) is not address(0) to
                 /// indicate keeper to create and update txData using finalizePayload()
-                LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ETH, 0, bytes("")),
+                LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ETH, 0),
                 bytes("")
             )
         );

--- a/test/unit/crosschain-data/utils/PayloadHelper.multiVault.t.sol
+++ b/test/unit/crosschain-data/utils/PayloadHelper.multiVault.t.sol
@@ -198,17 +198,15 @@ contract PayloadHelperMultiTest is ProtocolActions {
         uint64[] liqDstChainIds;
         uint256[] amounts;
         uint256[] nativeAmounts;
-        bytes[] permit2datas;
     }
 
     function _checkDstPayloadLiqData(TestAction memory action) internal {
         vm.selectFork(FORKS[DST_CHAINS[0]]);
         CheckDstPayloadLiqDataInternalVars memory v;
 
-        (v.bridgeIds, v.txDatas, v.tokens, v.liqDstChainIds, v.amounts,, v.nativeAmounts, v.permit2datas) =
-        IPayloadHelper(contracts[DST_CHAINS[0]][bytes32(bytes("PayloadHelper"))]).decodeCoreStateRegistryPayloadLiqData(
-            2
-        );
+        (v.bridgeIds, v.txDatas, v.tokens, v.liqDstChainIds, v.amounts,, v.nativeAmounts) = IPayloadHelper(
+            contracts[DST_CHAINS[0]][bytes32(bytes("PayloadHelper"))]
+        ).decodeCoreStateRegistryPayloadLiqData(2);
 
         assertEq(v.bridgeIds[0], 1);
 
@@ -219,8 +217,6 @@ contract PayloadHelperMultiTest is ProtocolActions {
         assertEq(v.liqDstChainIds[0], FINAL_LIQ_DST_WITHDRAW[POLY][0]);
 
         assertEq(v.amounts, AMOUNTS[POLY][0]);
-
-        assertEq(v.permit2datas[0].length, 0);
     }
 
     function _checkDstPayloadReturn() internal {

--- a/test/unit/crosschain-liquidity/LiquidityHandler.t.sol
+++ b/test/unit/crosschain-liquidity/LiquidityHandler.t.sol
@@ -12,14 +12,12 @@ contract LiquidityHandlerUser is LiquidityHandler {
         address token_,
         uint256 amount_,
         address owner_,
-        uint256 nativeAmount_,
-        bytes memory permit2Data_,
-        address permit2_
+        uint256 nativeAmount_
     )
         external
         payable
     {
-        dispatchTokens(bridge_, txData_, token_, amount_, owner_, nativeAmount_, permit2Data_, permit2_);
+        dispatchTokens(bridge_, txData_, token_, amount_, owner_, nativeAmount_);
     }
 }
 
@@ -50,72 +48,9 @@ contract LiquidityHandlerTest is BaseSetup {
             token,
             transferAmount,
             address(liquidityHandler),
-            0,
-            bytes(""),
-            address(0)
+            0
         );
         vm.stopPrank();
-    }
-
-    function test_dispatchTokensUsingApprovals() public {
-        uint256 transferAmount = 1e18;
-        /// 1 token
-        address payable token = payable(getContract(ETH, "DAI"));
-        address tokenDst = getContract(ARBI, "DAI");
-
-        /// @dev giving approval
-        vm.prank(deployer);
-        MockERC20(token).approve(address(liquidityHandler), transferAmount);
-
-        vm.prank(deployer);
-        liquidityHandler.dispatchTokensTest(
-            SuperRegistry(getContract(ETH, "SuperRegistry")).getBridgeAddress(1),
-            _buildTxData(
-                1, address(token), tokenDst, address(liquidityHandler), ARBI, transferAmount, address(liquidityHandler)
-            ),
-            token,
-            transferAmount,
-            deployer,
-            0,
-            bytes(""),
-            address(0)
-        );
-    }
-
-    function test_dispatchTokensWithPermit2() public {
-        uint256 transferAmount = 1e18;
-        /// 1 token
-        address payable token = payable(getContract(ETH, "USDT"));
-        address tokenDst = getContract(ARBI, "DAI");
-
-        /// @dev giving approval
-        IPermit2.PermitTransferFrom memory permit = IPermit2.PermitTransferFrom({
-            permitted: IPermit2.TokenPermissions({ token: IERC20(token), amount: transferAmount }),
-            nonce: _randomUint256(),
-            deadline: block.timestamp
-        });
-
-        bytes memory sig = _signPermit(permit, address(liquidityHandler), 777, ETH);
-        bytes memory permit2Calldata = abi.encode(permit.nonce, permit.deadline, sig);
-
-        address permit2 = SuperRegistry(getContract(ETH, "SuperRegistry")).PERMIT2();
-
-        vm.prank(deployer);
-        MockERC20(token).approve(getContract(ETH, "CanonicalPermit2"), type(uint256).max);
-
-        vm.prank(deployer);
-        liquidityHandler.dispatchTokensTest(
-            SuperRegistry(getContract(ETH, "SuperRegistry")).getBridgeAddress(1),
-            _buildTxData(
-                1, address(token), tokenDst, address(liquidityHandler), ARBI, transferAmount, address(liquidityHandler)
-            ),
-            address(token),
-            transferAmount,
-            deployer,
-            0,
-            permit2Calldata,
-            permit2
-        );
     }
 
     function test_dispatchTokensUsingFailingTxData() public {
@@ -138,9 +73,7 @@ contract LiquidityHandlerTest is BaseSetup {
             token,
             transferAmount,
             deployer,
-            0,
-            bytes(""),
-            address(0)
+            0
         );
     }
 
@@ -157,9 +90,7 @@ contract LiquidityHandlerTest is BaseSetup {
             token,
             transferAmount,
             deployer,
-            0,
-            bytes(""),
-            address(0)
+            0
         );
     }
 
@@ -176,9 +107,7 @@ contract LiquidityHandlerTest is BaseSetup {
             token,
             transferAmount,
             deployer,
-            transferAmount,
-            bytes(""),
-            address(0)
+            transferAmount
         );
     }
 

--- a/test/unit/libraries/ArrayCastLib.t.sol
+++ b/test/unit/libraries/ArrayCastLib.t.sol
@@ -21,7 +21,7 @@ contract ArrayCastLibTest is Test {
     }
 
     function test_castLiqRequestToArray() external {
-        LiqRequest memory req = LiqRequest(1, "", address(0), 1, 1 wei, "");
+        LiqRequest memory req = LiqRequest(1, "", address(0), 1, 1 wei);
 
         LiqRequest[] memory castedReq = arrayCastLib.castToArray(req);
         assertEq(castedReq.length, 1);

--- a/test/unit/libraries/PayloadUpdaterLib.t.sol
+++ b/test/unit/libraries/PayloadUpdaterLib.t.sol
@@ -126,7 +126,7 @@ contract PayloadUpdaterLibTest is Test {
         bytes memory bytesTxData = abi.encode(420);
         /// @dev checks for liquidity request validation
         vm.expectRevert(Error.CANNOT_UPDATE_WITHDRAW_TX_DATA.selector);
-        payloadUpdateLib.validateLiqReq(LiqRequest(1, bytesTxData, address(420), 1, 1e18, bytesTxData));
+        payloadUpdateLib.validateLiqReq(LiqRequest(1, bytesTxData, address(420), 1, 1e18));
     }
 
     /// WITHDRAW PAYLAOD UPDATER TESTS

--- a/test/unit/payments/PayMaster.t.sol
+++ b/test/unit/payments/PayMaster.t.sol
@@ -150,9 +150,7 @@ contract PayMasterTest is BaseSetup {
         vm.expectRevert(Error.ZERO_ADDRESS.selector);
         PayMaster(feeCollector).rebalanceTo(
             keccak256("CORE_REGISTRY_PROCESSOR"),
-            LiqRequest(
-                1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether, ""
-            ),
+            LiqRequest(1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether),
             420
         );
 
@@ -162,18 +160,14 @@ contract PayMasterTest is BaseSetup {
         vm.expectRevert(Error.INVALID_TXDATA_RECEIVER.selector);
         PayMaster(feeCollector).rebalanceTo(
             keccak256("CORE_REGISTRY_PROCESSOR"),
-            LiqRequest(
-                1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether, ""
-            ),
+            LiqRequest(1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether),
             ARBI
         );
 
         /// @dev admin moves the payment from fee collector (ideal conditions)
         PayMaster(feeCollector).rebalanceTo(
             keccak256("CORE_REGISTRY_PROCESSOR"),
-            LiqRequest(
-                1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, txProcessorARBI), NATIVE, ARBI, 1 ether, ""
-            ),
+            LiqRequest(1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, txProcessorARBI), NATIVE, ARBI, 1 ether),
             ARBI
         );
 
@@ -201,9 +195,7 @@ contract PayMasterTest is BaseSetup {
         vm.expectRevert(Error.ZERO_ADDRESS.selector);
         PayMaster(feeCollector).rebalanceTo(
             keccak256("CORE_REGISTRY_UPDATER"),
-            LiqRequest(
-                1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether, ""
-            ),
+            LiqRequest(1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether),
             420
         );
 
@@ -213,18 +205,14 @@ contract PayMasterTest is BaseSetup {
         vm.expectRevert(Error.INVALID_TXDATA_RECEIVER.selector);
         PayMaster(feeCollector).rebalanceTo(
             keccak256("CORE_REGISTRY_UPDATER"),
-            LiqRequest(
-                1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether, ""
-            ),
+            LiqRequest(1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, feeCollectorDst), NATIVE, ARBI, 1 ether),
             ARBI
         );
 
         /// @dev admin moves the payment from fee collector (ideal conditions)
         PayMaster(feeCollector).rebalanceTo(
             keccak256("CORE_REGISTRY_UPDATER"),
-            LiqRequest(
-                1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, txUpdaterARBI), NATIVE, ARBI, 1 ether, ""
-            ),
+            LiqRequest(1, _buildTxData(1, NATIVE, feeCollector, ARBI, 1 ether, txUpdaterARBI), NATIVE, ARBI, 1 ether),
             ARBI
         );
 
@@ -246,7 +234,7 @@ contract PayMasterTest is BaseSetup {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ETH);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 

--- a/test/unit/payments/PaymentHelper.t.sol
+++ b/test/unit/payments/PaymentHelper.t.sol
@@ -39,7 +39,8 @@ contract PaymentHelperTest is BaseSetup {
                     /// timelock
                     420,
                     420,
-                    LiqRequest(1, emptyBytes, address(0), ETH, 420, emptyBytes),
+                    LiqRequest(1, emptyBytes, address(0), ETH, 420),
+                    emptyBytes,
                     emptyBytes
                 )
             ),
@@ -55,7 +56,8 @@ contract PaymentHelperTest is BaseSetup {
                     /// timelock
                     420,
                     420,
-                    LiqRequest(1, emptyBytes, address(0), ETH, 420, emptyBytes),
+                    LiqRequest(1, emptyBytes, address(0), ETH, 420),
+                    emptyBytes,
                     emptyBytes
                 )
             ),
@@ -71,7 +73,8 @@ contract PaymentHelperTest is BaseSetup {
                     /// timelock
                     420,
                     420,
-                    LiqRequest(1, emptyBytes, address(0), ETH, 420, emptyBytes),
+                    LiqRequest(1, emptyBytes, address(0), ETH, 420),
+                    emptyBytes,
                     emptyBytes
                 )
             ),
@@ -92,7 +95,7 @@ contract PaymentHelperTest is BaseSetup {
         uint256MemoryArray[0] = 420;
 
         LiqRequest[] memory liqRequestMemoryArray = new LiqRequest[](1);
-        liqRequestMemoryArray[0] = LiqRequest(1, emptyBytes, address(0), ETH, 420, emptyBytes);
+        liqRequestMemoryArray[0] = LiqRequest(1, emptyBytes, address(0), ETH, 420);
 
         (,,, uint256 fees) = paymentHelper.estimateSingleDirectMultiVault(
             SingleDirectMultiVaultStateReq(
@@ -102,6 +105,7 @@ contract PaymentHelperTest is BaseSetup {
                     uint256MemoryArray,
                     uint256MemoryArray,
                     liqRequestMemoryArray,
+                    emptyBytes,
                     emptyBytes
                 )
             ),
@@ -118,6 +122,7 @@ contract PaymentHelperTest is BaseSetup {
                     uint256MemoryArray,
                     uint256MemoryArray,
                     liqRequestMemoryArray,
+                    emptyBytes,
                     emptyBytes
                 )
             ),
@@ -151,7 +156,8 @@ contract PaymentHelperTest is BaseSetup {
                     /// timelock
                     420,
                     420,
-                    LiqRequest(1, txData, address(0), ETH, 420, emptyBytes),
+                    LiqRequest(1, txData, address(0), ETH, 420),
+                    emptyBytes,
                     emptyBytes
                 )
             ),
@@ -184,7 +190,8 @@ contract PaymentHelperTest is BaseSetup {
                     /// timelock
                     420,
                     420,
-                    LiqRequest(1, txData, address(0), ETH, 420, emptyBytes),
+                    LiqRequest(1, txData, address(0), ETH, 420),
+                    emptyBytes,
                     emptyBytes
                 )
             ),
@@ -217,7 +224,8 @@ contract PaymentHelperTest is BaseSetup {
                     /// timelock
                     420,
                     420,
-                    LiqRequest(1, txData, address(0), ETH, 420, emptyBytes),
+                    LiqRequest(1, txData, address(0), ETH, 420),
+                    emptyBytes,
                     emptyBytes
                 )
             ),

--- a/test/unit/superform-forms/superform-form.ERC4626Form.t.sol
+++ b/test/unit/superform-forms/superform-form.ERC4626Form.t.sol
@@ -305,7 +305,7 @@ contract SuperformERC4626FormTest is ProtocolActions {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ETH);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -329,7 +329,7 @@ contract SuperformERC4626FormTest is ProtocolActions {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ETH);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 2e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 2e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -371,7 +371,8 @@ contract SuperformERC4626FormTest is ProtocolActions {
             superformId,
             2e18,
             100,
-            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ETH, 0, ""),
+            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ETH, 0),
+            "",
             ""
         );
 
@@ -405,7 +406,8 @@ contract SuperformERC4626FormTest is ProtocolActions {
             superformId,
             1e18,
             100,
-            LiqRequest(1, _buildMaliciousTxData(1, USDT, formBeacon, ETH, 2e18, deployer), USDT, ETH, 0, ""),
+            LiqRequest(1, _buildMaliciousTxData(1, USDT, formBeacon, ETH, 2e18, deployer), USDT, ETH, 0),
+            "",
             ""
         );
 
@@ -437,7 +439,7 @@ contract SuperformERC4626FormTest is ProtocolActions {
         vm.startPrank(getContract(ETH, "CoreStateRegistry"));
 
         InitSingleVaultData memory data = InitSingleVaultData(
-            1, 1, superformId, 1e18, 100, LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ARBI, 0, ""), ""
+            1, 1, superformId, 1e18, 100, LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ARBI, 0), ""
         );
 
         vm.expectRevert(Error.WITHDRAW_TX_DATA_NOT_UPDATED.selector);
@@ -475,8 +477,7 @@ contract SuperformERC4626FormTest is ProtocolActions {
                 _buildMaliciousTxData(1, getContract(ETH, "USDT"), formBeacon, ARBI, 2e18, deployer),
                 getContract(ETH, "USDT"),
                 ARBI,
-                0,
-                ""
+                0
             ),
             ""
         );
@@ -502,7 +503,7 @@ contract SuperformERC4626FormTest is ProtocolActions {
         MockERC20(getContract(ETH, "USDT")).transfer(formBeacon, 1e18);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -531,7 +532,7 @@ contract SuperformERC4626FormTest is ProtocolActions {
         bytes memory invalidTxData = abi.encode(1);
 
         InitSingleVaultData memory data = InitSingleVaultData(
-            1, 1, superformId, 1e18, 100, LiqRequest(1, invalidTxData, getContract(ETH, "WETH"), ARBI, 0, ""), ""
+            1, 1, superformId, 1e18, 100, LiqRequest(1, invalidTxData, getContract(ETH, "WETH"), ARBI, 0), ""
         );
 
         vm.startPrank(getContract(ETH, "CoreStateRegistry"));
@@ -582,7 +583,7 @@ contract SuperformERC4626FormTest is ProtocolActions {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ETH);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 

--- a/test/unit/superform-forms/superform-form.ERC4626KYCDao.t.sol
+++ b/test/unit/superform-forms/superform-form.ERC4626KYCDao.t.sol
@@ -25,7 +25,7 @@ contract SuperformERC4626KYCDaoFormTest is BaseSetup {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[2], ETH);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 

--- a/test/unit/superform-forms/superform-form.ERC4626Timelock.t.sol
+++ b/test/unit/superform-forms/superform-form.ERC4626Timelock.t.sol
@@ -38,7 +38,7 @@ contract SuperformERC4626TimelockFormTest is ProtocolActions {
         vm.stopPrank();
 
         InitSingleVaultData memory data = InitSingleVaultData(
-            1, 1, superformId, 1e18, 100, LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ARBI, 0, ""), ""
+            1, 1, superformId, 1e18, 100, LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ARBI, 0), ""
         );
 
         /// @dev simulating withdrawals with malicious tx data
@@ -73,7 +73,7 @@ contract SuperformERC4626TimelockFormTest is ProtocolActions {
         bytes memory invalidNonEmptyTxData = abi.encode(1);
 
         InitSingleVaultData memory data = InitSingleVaultData(
-            1, 1, superformId, 1e18, 100, LiqRequest(1, invalidNonEmptyTxData, address(0), ETH, 0, ""), ""
+            1, 1, superformId, 1e18, 100, LiqRequest(1, invalidNonEmptyTxData, address(0), ETH, 0), ""
         );
 
         /// @dev simulating withdrawals with malicious tx data
@@ -106,7 +106,7 @@ contract SuperformERC4626TimelockFormTest is ProtocolActions {
         vm.stopPrank();
 
         InitSingleVaultData memory data =
-            InitSingleVaultData(1, 1, superformId, 1e18, 100, LiqRequest(1, "", address(0), ETH, 0, ""), "");
+            InitSingleVaultData(1, 1, superformId, 1e18, 100, LiqRequest(1, "", address(0), ETH, 0), "");
 
         vm.prank(getContract(ETH, "CoreStateRegistry"));
         IBaseForm(superform).xChainWithdrawFromVault(data, deployer, ARBI);
@@ -156,7 +156,7 @@ contract SuperformERC4626TimelockFormTest is ProtocolActions {
             superformId,
             1e18,
             100,
-            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ETH, 0, ""),
+            LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ETH, 0),
             ""
         );
 
@@ -185,8 +185,9 @@ contract SuperformERC4626TimelockFormTest is ProtocolActions {
 
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[1], ETH);
 
-        SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+        SingleVaultSFData memory data = SingleVaultSFData(
+            superformId, 1e18, 100, LiqRequest(1, bytes(""), getContract(ETH, "USDT"), ETH, 0), bytes(""), bytes("")
+        );
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 

--- a/test/unit/superform-router/SuperformRouter.sERC20.t.sol
+++ b/test/unit/superform-router/SuperformRouter.sERC20.t.sol
@@ -94,7 +94,7 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ARBI);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -118,7 +118,7 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         superTransmuterSyncer.mintSingle(deployer, superformId, 1e18);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 10_001, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 10_001, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -171,10 +171,10 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](2);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
-        liqReq[1] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
+        liqReq[1] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -217,9 +217,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
 
-        LiqRequest memory liqReq = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
+        LiqRequest memory liqReq = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
 
-        SingleVaultSFData memory data = SingleVaultSFData(superformId, amount, maxSlippage, liqReq, "");
+        SingleVaultSFData memory data = SingleVaultSFData(superformId, amount, maxSlippage, liqReq, "", "");
 
         SingleXChainSingleVaultStateReq memory req = SingleXChainSingleVaultStateReq(ambIds, ETH, data);
 
@@ -268,9 +268,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -299,9 +299,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         /// @dev approves before call
@@ -334,9 +334,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         /// @dev approves before call
@@ -386,11 +386,10 @@ contract SuperformRouterSERC20Test is ProtocolActions {
             ),
             getContract(ARBI, "USDT"),
             ETH,
-            0,
-            ""
+            0
         );
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         /// @dev approves before call
@@ -422,9 +421,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         /// @dev approves before call
@@ -458,9 +457,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         /// @dev approves before call
@@ -493,9 +492,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         /// @dev approves before call
@@ -532,10 +531,10 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         maxSlippages[1] = 1000;
 
         LiqRequest[] memory liqReqs = new LiqRequest[](2);
-        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
-        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0, "");
+        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
+        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
@@ -554,7 +553,7 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         superformRouterSERC20.singleXChainMultiVaultWithdraw{ value: 2 ether }(req);
     }
 
-    function test_withdrawWithInvalidMaxSlippage() public {
+    function test_withdrawWithInvalidMaxSlippagea() public {
         _successfulMultiVaultDeposit();
 
         /// scenario: user deposits with his own collateral and has approved enough tokens
@@ -583,10 +582,10 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         maxSlippages[1] = 99_999;
 
         LiqRequest[] memory liqReqs = new LiqRequest[](2);
-        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
-        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0, "");
+        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
+        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
@@ -634,10 +633,10 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         maxSlippages[1] = 1000;
 
         LiqRequest[] memory liqReqs = new LiqRequest[](2);
-        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
-        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0, "");
+        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
+        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
@@ -666,7 +665,7 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ARBI);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -693,7 +692,8 @@ contract SuperformRouterSERC20Test is ProtocolActions {
             0,
             /// @dev 0 amount here and in the LiqRequest
             100,
-            LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""),
+            LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0),
+            "",
             ""
         );
 
@@ -750,9 +750,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -785,9 +785,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -823,9 +823,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
                 ),
                 getContract(ARBI, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -863,9 +863,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
                 ),
                 getContract(ETH, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -904,9 +904,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
                 ),
                 getContract(ARBI, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -945,9 +945,9 @@ contract SuperformRouterSERC20Test is ProtocolActions {
                 ),
                 getContract(ARBI, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -1034,16 +1034,15 @@ contract SuperformRouterSERC20Test is ProtocolActions {
             ),
             getContract(ETH, "USDT"),
             ARBI,
-            0,
-            ""
+            0
         );
         liqReqs[1] = LiqRequest(
             1,
             _buildLiqBridgeTxData(
                 LiqBridgeTxDataArgs(
                     1,
-                    getContract(ETH, "WETH"),
-                    getContract(ETH, "WETH"),
+                    getContract(ETH, "USDT"),
+                    getContract(ETH, "USDT"),
                     getContract(ARBI, "WETH"),
                     address(superformRouterSERC20),
                     ETH,
@@ -1056,20 +1055,18 @@ contract SuperformRouterSERC20Test is ProtocolActions {
                     0
                 )
             ),
-            getContract(ETH, "WETH"),
+            getContract(ETH, "USDT"),
             ARBI,
-            0,
-            ""
+            0
         );
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
         /// @dev approves before call
-        MockERC20(getContract(ETH, "USDT")).approve(address(superformRouterSERC20), 1e18);
-        MockERC20(getContract(ETH, "WETH")).approve(address(superformRouterSERC20), 1e18);
+        MockERC20(getContract(ETH, "USDT")).approve(address(superformRouterSERC20), 2e18);
         vm.recordLogs();
 
         superformRouterSERC20.singleXChainMultiVaultDeposit{ value: 10 ether }(req);

--- a/test/unit/superform-router/SuperformRouter.t.sol
+++ b/test/unit/superform-router/SuperformRouter.t.sol
@@ -21,7 +21,7 @@ contract SuperformRouterTest is ProtocolActions {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ARBI);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -61,10 +61,10 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](2);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
-        liqReq[1] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
+        liqReq[1] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleDirectMultiVaultStateReq memory req = SingleDirectMultiVaultStateReq(data);
 
@@ -86,7 +86,7 @@ contract SuperformRouterTest is ProtocolActions {
         SuperPositions(getContract(ETH, "SuperPositions")).mintSingle(deployer, superformId, 1e18);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 10_001, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 10_001, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -127,10 +127,10 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](2);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
-        liqReq[1] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
+        liqReq[1] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -162,9 +162,9 @@ contract SuperformRouterTest is ProtocolActions {
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
 
-        LiqRequest memory liqReq = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
+        LiqRequest memory liqReq = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
 
-        SingleVaultSFData memory data = SingleVaultSFData(superformId, amount, maxSlippage, liqReq, "");
+        SingleVaultSFData memory data = SingleVaultSFData(superformId, amount, maxSlippage, liqReq, "", "");
 
         SingleXChainSingleVaultStateReq memory req = SingleXChainSingleVaultStateReq(ambIds, ETH, data);
 
@@ -200,9 +200,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -233,9 +233,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         address superformRouter = getContract(ETH, "SuperformRouter");
@@ -269,9 +269,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         address superformRouter = getContract(ETH, "SuperformRouter");
@@ -322,11 +322,10 @@ contract SuperformRouterTest is ProtocolActions {
             ),
             getContract(ARBI, "USDT"),
             ETH,
-            0,
-            ""
+            0
         );
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         address superformRouter = getContract(ETH, "SuperformRouter");
@@ -359,9 +358,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         address superformRouter = getContract(ETH, "SuperformRouter");
@@ -396,9 +395,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         address superformRouter = getContract(ETH, "SuperformRouter");
@@ -432,9 +431,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
         address superformRouter = getContract(ETH, "SuperformRouter");
@@ -476,10 +475,10 @@ contract SuperformRouterTest is ProtocolActions {
         maxSlippages[1] = 1000;
 
         LiqRequest[] memory liqReqs = new LiqRequest[](2);
-        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
-        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0, "");
+        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
+        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
@@ -521,10 +520,10 @@ contract SuperformRouterTest is ProtocolActions {
         maxSlippages[1] = 1000;
 
         LiqRequest[] memory liqReqs = new LiqRequest[](2);
-        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
-        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0, "");
+        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
+        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
@@ -568,10 +567,10 @@ contract SuperformRouterTest is ProtocolActions {
         maxSlippages[1] = 99_999;
 
         LiqRequest[] memory liqReqs = new LiqRequest[](2);
-        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, "");
-        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0, "");
+        liqReqs[0] = LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0);
+        liqReqs[1] = LiqRequest(1, "", getContract(ETH, "WETH"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
@@ -596,7 +595,7 @@ contract SuperformRouterTest is ProtocolActions {
         uint256 superformId = DataLib.packSuperform(superform, FORM_BEACON_IDS[0], ARBI);
 
         SingleVaultSFData memory data =
-            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""), "");
+            SingleVaultSFData(superformId, 1e18, 100, LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0), "", "");
 
         SingleDirectSingleVaultStateReq memory req = SingleDirectSingleVaultStateReq(data);
 
@@ -625,7 +624,8 @@ contract SuperformRouterTest is ProtocolActions {
             0,
             /// @dev 0 amount here and in the LiqRequest
             100,
-            LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0, ""),
+            LiqRequest(1, "", getContract(ETH, "USDT"), ETH, 0),
+            "",
             ""
         );
 
@@ -668,9 +668,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -705,9 +705,9 @@ contract SuperformRouterTest is ProtocolActions {
         ambIds[0] = 1;
 
         LiqRequest[] memory liqReq = new LiqRequest[](1);
-        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0, "");
+        liqReq[0] = LiqRequest(1, "", getContract(ARBI, "USDT"), ETH, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReq, "", "");
 
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
@@ -744,9 +744,9 @@ contract SuperformRouterTest is ProtocolActions {
                 ),
                 getContract(ARBI, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -785,9 +785,9 @@ contract SuperformRouterTest is ProtocolActions {
                 ),
                 getContract(ETH, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -827,9 +827,9 @@ contract SuperformRouterTest is ProtocolActions {
                 ),
                 getContract(ARBI, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -869,9 +869,9 @@ contract SuperformRouterTest is ProtocolActions {
                 ),
                 getContract(ARBI, "USDT"),
                 ETH,
-                0,
-                ""
+                0
             ),
+            "",
             ""
         );
 
@@ -931,12 +931,12 @@ contract SuperformRouterTest is ProtocolActions {
         );
 
         LiqRequest[] memory liqReqs = new LiqRequest[](2);
-        liqReqs[0] = LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ARBI, 0, "");
+        liqReqs[0] = LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ARBI, 0);
 
         liqBridgeTxDataArgs = LiqBridgeTxDataArgs(
             1,
-            getContract(ETH, "WETH"),
-            getContract(ETH, "WETH"),
+            getContract(ETH, "USDT"),
+            getContract(ETH, "USDT"),
             getContract(ARBI, "WETH"),
             superformRouter,
             ETH,
@@ -950,16 +950,15 @@ contract SuperformRouterTest is ProtocolActions {
             0
         );
 
-        liqReqs[1] = LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "WETH"), ARBI, 0, "");
+        liqReqs[1] = LiqRequest(1, _buildLiqBridgeTxData(liqBridgeTxDataArgs), getContract(ETH, "USDT"), ARBI, 0);
 
-        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "");
+        MultiVaultSFData memory data = MultiVaultSFData(superformIds, amounts, maxSlippages, liqReqs, "", "");
         uint8[] memory ambIds = new uint8[](1);
         ambIds[0] = 1;
         SingleXChainMultiVaultStateReq memory req = SingleXChainMultiVaultStateReq(ambIds, ARBI, data);
 
         /// @dev approves before call
-        MockERC20(getContract(ETH, "USDT")).approve(superformRouter, 1e18);
-        MockERC20(getContract(ETH, "WETH")).approve(superformRouter, 1e18);
+        MockERC20(getContract(ETH, "USDT")).approve(superformRouter, 2e18);
         vm.recordLogs();
 
         SuperformRouter(payable(superformRouter)).singleXChainMultiVaultDeposit{ value: 2 ether }(req);

--- a/test/utils/ProtocolActions.sol
+++ b/test/utils/ProtocolActions.sol
@@ -1252,6 +1252,13 @@ abstract contract ProtocolActions is BaseSetup {
         }
     }
 
+    struct MultiVaultCallDataVars {
+        IPermit2.PermitTransferFrom permit;
+        bytes sig;
+        bytes permit2data;
+        uint256 totalAmount;
+    }
+
     /// @dev this internal function just loops over _buildSingleVaultDepositCallData or
     /// _buildSingleVaultWithdrawCallData to build MultiVaultSFData
     function _buildMultiVaultCallData(
@@ -1261,10 +1268,15 @@ abstract contract ProtocolActions is BaseSetup {
         internal
         returns (MultiVaultSFData memory superformsData)
     {
+        MultiVaultCallDataVars memory v;
+
         SingleVaultSFData memory superformData;
         uint256 len = args.superformIds.length;
+
         LiqRequest[] memory liqRequests = new LiqRequest[](len);
         SingleVaultCallDataArgs memory callDataArgs;
+
+        v.totalAmount;
 
         if (len == 0) revert LEN_MISMATCH();
         uint256[] memory finalAmounts = new uint256[](len);
@@ -1315,9 +1327,27 @@ abstract contract ProtocolActions is BaseSetup {
             }
             liqRequests[i] = superformData.liqRequest;
             maxSlippageTemp[i] = args.maxSlippage;
+            v.totalAmount += finalAmounts[i];
         }
+
+        if (action == Actions.DepositPermit2) {
+            v.permit = IPermit2.PermitTransferFrom({
+                permitted: IPermit2.TokenPermissions({ token: IERC20(address(args.externalToken)), amount: v.totalAmount }),
+                nonce: _randomUint256(),
+                deadline: block.timestamp
+            });
+            /// @dev from is always SuperformRouter
+            v.sig = _signPermit(v.permit, args.fromSrc, userKeys[args.user], args.srcChainId);
+            v.permit2data = abi.encode(v.permit.nonce, v.permit.deadline, v.sig);
+        }
+
         superformsData = MultiVaultSFData(
-            args.superformIds, finalAmounts, maxSlippageTemp, liqRequests, abi.encode(args.partialWithdrawVaults)
+            args.superformIds,
+            finalAmounts,
+            maxSlippageTemp,
+            liqRequests,
+            v.permit2data,
+            abi.encode(args.partialWithdrawVaults)
         );
     }
 
@@ -1478,13 +1508,7 @@ abstract contract ProtocolActions is BaseSetup {
 
         /// @dev the actual liq request struct inscription
         v.liqReq = LiqRequest(
-            args.liqBridge,
-            v.txData,
-            liqRequestToken,
-            args.toChainId,
-            liqRequestToken == NATIVE_TOKEN ? args.amount : 0,
-            /// @dev for native actions amount is also here
-            v.permit2Calldata
+            args.liqBridge, v.txData, liqRequestToken, args.toChainId, liqRequestToken == NATIVE_TOKEN ? args.amount : 0
         );
 
         if (liqRequestToken != NATIVE_TOKEN) {
@@ -1504,7 +1528,9 @@ abstract contract ProtocolActions is BaseSetup {
 
         /// @dev extraData is unused here so false is encoded (it is currently used to send in the partialWithdraw
         /// vaults without resorting to extra args, just for withdraws)
-        superformData = SingleVaultSFData(args.superformId, args.amount, args.maxSlippage, v.liqReq, abi.encode(false));
+        superformData = SingleVaultSFData(
+            args.superformId, args.amount, args.maxSlippage, v.liqReq, v.permit2Calldata, abi.encode(false)
+        );
     }
 
     struct SingleVaultWithdrawLocalVars {
@@ -1571,14 +1597,13 @@ abstract contract ProtocolActions is BaseSetup {
             /// @dev for certain test cases, insert txData as null here
             args.underlyingTokenDst,
             args.liqDstChainId,
-            0,
-            ""
+            0
         );
 
         /// @dev extraData is currently used to send in the partialWithdraw vaults without resorting to extra args, just
         /// for withdraws
         superformData = SingleVaultSFData(
-            args.superformId, args.amount, args.maxSlippage, vars.liqReq, abi.encode(args.partialWithdrawVault)
+            args.superformId, args.amount, args.maxSlippage, vars.liqReq, "", abi.encode(args.partialWithdrawVault)
         );
     }
 


### PR DESCRIPTION
- Only one approval is done by the user for multi-vault deposits
- Only one permit2 data is sent along with the request
- permit2 data is not transferred xChain as it is irrelevant, reducing the xChain messaging cost significantly 