### PR TITLE
chore: clean up bridge validators, remove validation

### DIFF
--- a/src/crosschain-liquidity/BridgeValidator.sol
+++ b/src/crosschain-liquidity/BridgeValidator.sol
@@ -27,17 +27,6 @@ abstract contract BridgeValidator is IBridgeValidator {
     //////////////////////////////////////////////////////////////*/
 
     /// @inheritdoc IBridgeValidator
-    function validateLiqDstChainId(
-        bytes calldata txData_,
-        uint64 liqDstChainId_
-    )
-        external
-        pure
-        virtual
-        override
-        returns (bool);
-
-    /// @inheritdoc IBridgeValidator
     function validateReceiver(
         bytes calldata txData_,
         address receiver_

--- a/src/crosschain-liquidity/lifi/LiFiValidator.sol
+++ b/src/crosschain-liquidity/lifi/LiFiValidator.sol
@@ -18,19 +18,6 @@ contract LiFiValidator is BridgeValidator, LiFiTxDataExtractor {
     constructor(address superRegistry_) BridgeValidator(superRegistry_) { }
 
     /// @inheritdoc BridgeValidator
-    function validateLiqDstChainId(
-        bytes calldata txData_,
-        uint64 liqDstChainId_
-    )
-        external
-        pure
-        override
-        returns (bool)
-    {
-        return (uint256(liqDstChainId_) == _extractBridgeData(txData_).destinationChainId);
-    }
-
-    /// @inheritdoc BridgeValidator
     function validateReceiver(bytes calldata txData_, address receiver_) external pure override returns (bool valid_) {
         return _extractBridgeData(txData_).receiver == receiver_;
     }

--- a/src/crosschain-liquidity/socket/SocketOneInchValidator.sol
+++ b/src/crosschain-liquidity/socket/SocketOneInchValidator.sol
@@ -17,18 +17,6 @@ contract SocketOneInchValidator is BridgeValidator {
     /*///////////////////////////////////////////////////////////////
                             EXTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/
-    /// @inheritdoc BridgeValidator
-    function validateLiqDstChainId(
-        bytes calldata, /*txData_*/
-        uint64 /*liqDstChainId_*/
-    )
-        external
-        pure
-        override
-        returns (bool)
-    {
-        revert();
-    }
 
     /// @inheritdoc BridgeValidator
     function validateReceiver(bytes calldata txData_, address receiver) external pure override returns (bool) {

--- a/src/crosschain-liquidity/socket/SocketValidator.sol
+++ b/src/crosschain-liquidity/socket/SocketValidator.sol
@@ -17,18 +17,6 @@ contract SocketValidator is BridgeValidator {
     /*///////////////////////////////////////////////////////////////
                             EXTERNAL FUNCTIONS
     //////////////////////////////////////////////////////////////*/
-    /// @inheritdoc BridgeValidator
-    function validateLiqDstChainId(
-        bytes calldata txData_,
-        uint64 liqDstChainId_
-    )
-        external
-        pure
-        override
-        returns (bool)
-    {
-        return (uint256(liqDstChainId_) == _decodeTxData(txData_).toChainId);
-    }
 
     /// @inheritdoc BridgeValidator
     function validateReceiver(bytes calldata txData_, address receiver) external pure override returns (bool) {

--- a/src/interfaces/IBridgeValidator.sol
+++ b/src/interfaces/IBridgeValidator.sol
@@ -22,12 +22,7 @@ interface IBridgeValidator {
                             External Functions
     //////////////////////////////////////////////////////////////*/
 
-    /// @dev validates the destination chainId of the liquidity request
-    /// @param txData_ the txData of the deposit
-    /// @param liqDstChainId_ the chainId of the destination chain for liquidity
-    function validateLiqDstChainId(bytes calldata txData_, uint64 liqDstChainId_) external pure returns (bool);
-
-    /// @dev decoded txData and returns the receiver address
+    /// @dev validates the receiver of the liquidity request
     /// @param txData_ is the txData of the cross chain deposit
     /// @param receiver_ is the address of the receiver to validate
     /// @return valid_ if the address is valid
@@ -37,7 +32,7 @@ interface IBridgeValidator {
     /// @param args_ the txData arguments to validate in txData
     function validateTxData(ValidateTxDataArgs calldata args_) external view;
 
-    /// @dev decodes the txData and returns the amount of external token on source
+    /// @dev decodes the txData and returns the amount of input token on source
     /// @param txData_ is the txData of the cross chain deposit
     /// @param genericSwapDisallowed_ true if generic swaps are disallowed
     /// @return amount_ the amount expected
@@ -49,7 +44,7 @@ interface IBridgeValidator {
         view
         returns (uint256 amount_);
 
-    /// @dev decodes the amount in from the txData that just involves a swap
+    /// @dev decodes neccesary information for processing swaps on the destination chain
     /// @param txData_ is the txData to be decoded
     /// @return token_ is the address of the token
     /// @return amount_ the amount expected

--- a/src/payments/PayMaster.sol
+++ b/src/payments/PayMaster.sol
@@ -132,12 +132,6 @@ contract PayMaster is IPayMaster, LiquidityHandler {
             revert Error.INVALID_TXDATA_RECEIVER();
         }
 
-        valid = IBridgeValidator(bridgeValidator).validateLiqDstChainId(liqRequest_.txData, liqRequest_.liqDstChainId);
-
-        if (!valid) {
-            revert Error.INVALID_TXDATA_CHAIN_ID();
-        }
-
         _dispatchTokens(
             superRegistry.getBridgeAddress(liqRequest_.bridgeId),
             liqRequest_.txData,

--- a/test/unit/crosschain-liquidity/socket/SocketValidator.t.sol
+++ b/test/unit/crosschain-liquidity/socket/SocketValidator.t.sol
@@ -108,14 +108,4 @@ contract SocketValidatorTest is ProtocolActions {
 
         assertEq(SocketValidator(getContract(ETH, "SocketValidator")).decodeAmountIn(txData, true), uint256(100));
     }
-
-    function test_validate_liq_dst_chain_id() public {
-        bytes memory txData = _buildDummyTxDataUnitTests(
-            BuildDummyTxDataUnitTestsVars(
-                2, address(0), address(0), deployer, ETH, BSC, uint256(100), getContract(BSC, "PayMaster"), false
-            )
-        );
-
-        assertTrue(SocketValidator(getContract(ETH, "SocketValidator")).validateLiqDstChainId(txData, BSC));
-    }
 }

--- a/test/unit/payments/PayMaster.t.sol
+++ b/test/unit/payments/PayMaster.t.sol
@@ -183,11 +183,6 @@ contract PayMasterTest is ProtocolActions {
         txData = _buildDummyTxDataUnitTests(
             BuildDummyTxDataUnitTestsVars(1, NATIVE, NATIVE, feeCollector, ETH, ARBI, 1 ether, txProcessorARBI, false)
         );
-        /// @dev admin moves the payment from fee collector to different address on another chain
-        vm.expectRevert(Error.INVALID_TXDATA_CHAIN_ID.selector);
-        PayMaster(payable(feeCollector)).rebalanceTo(
-            keccak256("CORE_REGISTRY_PROCESSOR"), LiqRequest(1, txData, NATIVE, ETH, 1 ether), ARBI
-        );
 
         /// @dev admin moves the payment from fee collector (ideal conditions)
         PayMaster(payable(feeCollector)).rebalanceTo(


### PR DESCRIPTION
Check was only being used in PayMaster and don't think it's really that useful since it's admin generated txData, streamlines validation logic