### PR TITLE
chore: adding totalSupply

### DIFF
--- a/src/BaseForm.sol
+++ b/src/BaseForm.sol
@@ -141,6 +141,9 @@ abstract contract BaseForm is Initializable, ERC165, IBaseForm {
     /// @inheritdoc IBaseForm
     function getTotalAssets() public view virtual override returns (uint256);
 
+    /// @inheritdoc IBaseForm
+    function getTotalSupply() public view virtual override returns (uint256);
+
     // @inheritdoc IBaseForm
     function getPreviewPricePerVaultShare() public view virtual override returns (uint256);
 

--- a/src/forms/ERC4626FormImplementation.sol
+++ b/src/forms/ERC4626FormImplementation.sol
@@ -109,6 +109,11 @@ abstract contract ERC4626FormImplementation is BaseForm, LiquidityHandler {
     }
 
     /// @inheritdoc BaseForm
+    function getTotalSupply() public view virtual override returns (uint256) {
+        return IERC4626(vault).totalSupply();
+    }
+
+    /// @inheritdoc BaseForm
     function getPreviewPricePerVaultShare() public view virtual override returns (uint256) {
         uint256 vaultDecimals = IERC4626(vault).decimals();
         return IERC4626(vault).previewRedeem(10 ** vaultDecimals);

--- a/src/forms/interfaces/IERC4626Form.sol
+++ b/src/forms/interfaces/IERC4626Form.sol
@@ -28,6 +28,8 @@ interface IERC4626Form is IERC20 {
 
     function getTotalAssets() external view returns (uint256);
 
+    function getTotalSupply() external view returns (uint256);
+
     function getPreviewPricePerVaultShare() external view returns (uint256);
 
     function previewDepositTo(uint256 assets_) external view returns (uint256);

--- a/src/interfaces/IBaseForm.sol
+++ b/src/interfaces/IBaseForm.sol
@@ -71,6 +71,9 @@ interface IBaseForm is IERC165 {
     /// @notice get the total amount of underlying managed in the ERC4626 vault
     function getTotalAssets() external view returns (uint256);
 
+    /// @notice get the total amount of unredeemed vault shares in circulation
+    function getTotalSupply() external view returns (uint256);
+
     /// @notice get the total amount of assets received if shares are actually redeemed
     /// @notice https://eips.ethereum.org/EIPS/eip-4626
     function getPreviewPricePerVaultShare() external view returns (uint256);

--- a/test/mocks/InterfaceNotSupported/BaseFormInterfaceNotSupported.sol
+++ b/test/mocks/InterfaceNotSupported/BaseFormInterfaceNotSupported.sol
@@ -209,6 +209,9 @@ abstract contract BaseForm is Initializable, ERC165, IBaseForm {
     function getTotalAssets() public view virtual override returns (uint256);
 
     /// @inheritdoc IBaseForm
+    function getTotalSupply() public view virtual override returns (uint256);
+
+    /// @inheritdoc IBaseForm
     function getStateRegistryId() external view virtual override returns (uint8);
 
     // @inheritdoc IBaseForm

--- a/test/mocks/InterfaceNotSupported/ERC4626ImplementationInterfaceNotSupported.sol
+++ b/test/mocks/InterfaceNotSupported/ERC4626ImplementationInterfaceNotSupported.sol
@@ -68,6 +68,11 @@ abstract contract ERC4626FormImplementationInterfaceNotSupported is BaseForm, Li
     }
 
     /// @inheritdoc BaseForm
+    function getTotalSupply() public view virtual override returns (uint256) {
+        return IERC4626(vault).totalSupply();
+    }
+
+    /// @inheritdoc BaseForm
     function getPreviewPricePerVaultShare() public view virtual override returns (uint256) {
         uint256 vaultDecimals = IERC4626(vault).decimals();
         return IERC4626(vault).previewRedeem(10 ** vaultDecimals);

--- a/test/unit/superform-forms/superform-form.ERC4626Form.t.sol
+++ b/test/unit/superform-forms/superform-form.ERC4626Form.t.sol
@@ -178,6 +178,36 @@ contract SuperformERC4626FormTest is ProtocolActions {
         assertEq(totalAssets, 0);
     }
 
+    function test_superformVaultTotalSupply() public {
+        vm.startPrank(deployer);
+
+        vm.selectFork(FORKS[chainId]);
+
+        address superRegistry = getContract(chainId, "SuperRegistry");
+
+        /// @dev Deploying Forms
+        address formImplementation = address(new ERC4626Form(superRegistry));
+        uint32 formImplementationId = 0;
+
+        /// @dev Vaults For The Superforms
+        MockERC20 asset = new MockERC20("Mock ERC20 Token", "Mock", address(this), uint256(1000));
+        VaultMock vault = new VaultMock(asset, "Mock Vault", "Mock");
+
+        // Deploying Forms Using AddImplementation. Not Testing Reverts As Already Tested
+        SuperformFactory(getContract(chainId, "SuperformFactory")).addFormImplementation(
+            formImplementation, formImplementationId
+        );
+
+        /// @dev Creating superform using formImplementationId and vault
+        (, address superformCreated) = SuperformFactory(getContract(chainId, "SuperformFactory")).createSuperform(
+            formImplementationId, address(vault)
+        );
+
+        uint256 totalSupply = ERC4626Form(payable(superformCreated)).getTotalSupply();
+
+        assertEq(totalSupply, 0);
+    }
+
     function test_superformVaultShareBalance() public {
         vm.startPrank(deployer);
 


### PR DESCRIPTION
Wrapping `totalSupply` -- some vaults where preview and convert functions might revert will require this to properly calculate APY