### PR TITLE
fix: Revoke broadcast roles

### DIFF
--- a/script/forge-scripts/misc/Abstract.EnableBroadcasting.s.sol
+++ b/script/forge-scripts/misc/Abstract.EnableBroadcasting.s.sol
@@ -217,6 +217,6 @@ abstract contract AbstractEnableBroadcasting is BatchScript, EnvironmentUtils {
         addToBatch(address(vars.superRBACC), 0, txn);
 
         /// Send to Safe to sign
-        executeBatch(vars.chainId, env == 0 ? PROTOCOL_ADMINS[trueIndex] : PROTOCOL_ADMINS_STAGING[i], false);
+        executeBatch(vars.chainId, env == 0 ? PROTOCOL_ADMINS[trueIndex] : PROTOCOL_ADMINS_STAGING[i], true);
     }
 }

--- a/script/forge-scripts/misc/Abstract.EnableBroadcasting.s.sol
+++ b/script/forge-scripts/misc/Abstract.EnableBroadcasting.s.sol
@@ -145,4 +145,78 @@ abstract contract AbstractEnableBroadcasting is BatchScript, EnvironmentUtils {
         /// Send to Safe to sign
         executeBatch(vars.chainId, env == 0 ? PROTOCOL_ADMINS[trueIndex] : PROTOCOL_ADMINS_STAGING[i], true);
     }
+
+    function _revokeRole(
+        uint256 env,
+        uint256 i,
+        uint256 trueIndex,
+        Cycle cycle,
+        uint64[] memory targetDeploymentChains
+    )
+        internal
+        setEnvDeploy(cycle)
+    {
+        UpdateVars memory vars;
+
+        vars.chainId = targetDeploymentChains[i];
+        vm.startBroadcast();
+        vars.superRegistry = _readContractsV1(env, chainNames[trueIndex], vars.chainId, "SuperRegistry");
+        vars.superRegistryC = SuperRegistry(vars.superRegistry);
+        vars.superRBAC = _readContractsV1(env, chainNames[trueIndex], vars.chainId, "SuperRBAC");
+        vars.superRBACC = SuperRBAC(vars.superRBAC);
+
+        vars.broadcastRegistry = _readContractsV1(env, chainNames[trueIndex], vars.chainId, "BroadcastRegistry");
+
+        if (vars.superRegistry == address(0) || vars.broadcastRegistry == address(0) || vars.superRBAC == address(0)) {
+            revert();
+        }
+        /// revoke addresses in super rbac
+        vars.superRBACC.revokeRole(vars.superRBACC.BROADCAST_STATE_REGISTRY_PROCESSOR_ROLE(), EMERGENCY_ADMIN);
+
+        vars.superRBACC.revokeRole(vars.superRBACC.WORMHOLE_VAA_RELAYER_ROLE(), EMERGENCY_ADMIN);
+
+        vm.stopBroadcast();
+    }
+
+    function _revokeRoleProd(
+        uint256 env,
+        uint256 i,
+        uint256 trueIndex,
+        Cycle cycle,
+        uint64[] memory targetDeploymentChains
+    )
+        internal
+        setEnvDeploy(cycle)
+    {
+        UpdateVars memory vars;
+
+        vars.chainId = targetDeploymentChains[i];
+        vars.superRegistry = _readContractsV1(env, chainNames[trueIndex], vars.chainId, "SuperRegistry");
+        vars.superRegistryC = SuperRegistry(vars.superRegistry);
+        vars.superRBAC = _readContractsV1(env, chainNames[trueIndex], vars.chainId, "SuperRBAC");
+        vars.superRBACC = SuperRBAC(vars.superRBAC);
+
+        vars.broadcastRegistry = _readContractsV1(env, chainNames[trueIndex], vars.chainId, "BroadcastRegistry");
+
+        if (vars.superRegistry == address(0) || vars.broadcastRegistry == address(0) || vars.superRBAC == address(0)) {
+            revert();
+        }
+
+        bytes memory txn = abi.encodeWithSelector(
+            vars.superRBACC.revokeRole.selector,
+            vars.superRBACC.BROADCAST_STATE_REGISTRY_PROCESSOR_ROLE(),
+            EMERGENCY_ADMIN
+        );
+
+        addToBatch(address(vars.superRBACC), 0, txn);
+
+        txn = abi.encodeWithSelector(
+            vars.superRBACC.revokeRole.selector, vars.superRBACC.WORMHOLE_VAA_RELAYER_ROLE(), EMERGENCY_ADMIN
+        );
+
+        addToBatch(address(vars.superRBACC), 0, txn);
+
+        /// Send to Safe to sign
+        executeBatch(vars.chainId, env == 0 ? PROTOCOL_ADMINS[trueIndex] : PROTOCOL_ADMINS_STAGING[i], false);
+    }
 }

--- a/script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol
+++ b/script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol
@@ -19,4 +19,20 @@ contract MainnetEnableBroadcasting is AbstractEnableBroadcasting {
             ? _enableBroadcasting(env, selectedChainIndex, trueIndex, Cycle.Prod, TARGET_CHAINS)
             : _enableBroadcastingProd(env, selectedChainIndex, trueIndex, Cycle.Prod, TARGET_CHAINS);
     }
+
+    function fixRevokeRole(uint256 env, uint256 selectedChainIndex) external {
+        _setEnvironment(env);
+
+        uint256 trueIndex;
+        for (uint256 i = 0; i < chainIds.length; i++) {
+            if (TARGET_CHAINS[selectedChainIndex] == chainIds[i]) {
+                trueIndex = i;
+                break;
+            }
+        }
+
+        env == 1
+            ? _revokeRole(env, selectedChainIndex, trueIndex, Cycle.Prod, TARGET_CHAINS)
+            : _revokeRoleProd(env, selectedChainIndex, trueIndex, Cycle.Prod, TARGET_CHAINS);
+    }
 }

--- a/script/utils/misc/run_script_mainnet_enableBroadcasting_revokeRoles_safe.sh
+++ b/script/utils/misc/run_script_mainnet_enableBroadcasting_revokeRoles_safe.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Note: How to set defaultKey - https://www.youtube.com/watch?v=VQe7cIpaE54
+
+export ETHEREUM_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/ETHEREUM_RPC_URL/credential)
+export BSC_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/BSC_RPC_URL/credential)
+export AVALANCHE_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/AVALANCHE_RPC_URL/credential)
+export POLYGON_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/POLYGON_RPC_URL/credential)
+export ARBITRUM_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/ARBITRUM_RPC_URL/credential)
+export OPTIMISM_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/OPTIMISM_RPC_URL/credential)
+export BASE_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/BASE_RPC_URL/credential)
+
+echo Enable Broadcasting: Queuing up safe transactions for protocol admin to sign: ...
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 0 0 --rpc-url $ETHEREUM_RPC_URL --slow --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 0 1 --rpc-url $BSC_RPC_URL --slow --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 0 2 --rpc-url $AVALANCHE_RPC_URL --slow --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 0 3 --rpc-url $POLYGON_RPC_URL --slow --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 0 4 --rpc-url $ARBITRUM_RPC_URL --slow --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92 --legacy
+
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 0 5 --rpc-url $OPTIMISM_RPC_URL --slow --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 0 6 --rpc-url $BASE_RPC_URL --slow --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92

--- a/script/utils/misc/run_script_mainnet_staging_enableBroadcasting_revoke.sh
+++ b/script/utils/misc/run_script_mainnet_staging_enableBroadcasting_revoke.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Note: How to set defaultKey - https://www.youtube.com/watch?v=VQe7cIpaE54
+
+export ETHEREUM_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/ETHEREUM_RPC_URL/credential)
+export BSC_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/BSC_RPC_URL/credential)
+export AVALANCHE_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/AVALANCHE_RPC_URL/credential)
+export POLYGON_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/POLYGON_RPC_URL/credential)
+export ARBITRUM_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/ARBITRUM_RPC_URL/credential)
+export OPTIMISM_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/OPTIMISM_RPC_URL/credential)
+export BASE_RPC_URL=$(op read op://5ylebqljbh3x6zomdxi3qd7tsa/BASE_RPC_URL/credential)
+
+# Run the script
+echo Revoking roles re. broadcasting...
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 1 0 --rpc-url $BSC_RPC_URL --broadcast --slow --account defaultKey --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 1 1 --rpc-url $ARBITRUM_RPC_URL --broadcast --slow --account defaultKey --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92 --legacy
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 1 2 --rpc-url $OPTIMISM_RPC_URL --broadcast --slow --account defaultKey --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+wait
+
+FOUNDRY_PROFILE=default forge script script/forge-scripts/misc/Mainnet.EnableBroadcasting.s.sol:MainnetEnableBroadcasting --sig "fixRevokeRole(uint256,uint256)" 1 3 --rpc-url $BASE_RPC_URL --broadcast --slow --account defaultKey --sender 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92
+wait

--- a/test/mainnet/SmokeTest.Staging.t.sol
+++ b/test/mainnet/SmokeTest.Staging.t.sol
@@ -41,7 +41,7 @@ contract SmokeTestStaging is MainnetBaseSetup {
         address[] memory newAddresses = new address[](len);
         newAddresses[0] = 0xc5c971e6B9F01dcf06bda896AEA3648eD6e3EFb3;
         newAddresses[1] = 0x2759142A9e3cBbcCc1E3d5F76490eEE4007B8943;
-        newAddresses[2] = EMERGENCY_ADMIN;
+        newAddresses[2] = 0x65c2d7e8d31C845894491ABe5789Ba1e5d4382fC;
         newAddresses[3] = EMERGENCY_ADMIN;
         newAddresses[4] = 0xF1c73958118F22Fc3A3947f405DcEBF08a1E68f7;
         newAddresses[5] = 0xe1A61d90554131314cB30dB55B8AD4F4b6e21C3a;
@@ -102,7 +102,7 @@ contract SmokeTestStaging is MainnetBaseSetup {
             newAddresses[10] = 0xc5c971e6B9F01dcf06bda896AEA3648eD6e3EFb3;
             newAddresses[11] = 0x2759142A9e3cBbcCc1E3d5F76490eEE4007B8943;
             newAddresses[12] = 0xF1c73958118F22Fc3A3947f405DcEBF08a1E68f7;
-            newAddresses[13] = EMERGENCY_ADMIN;
+            newAddresses[13] = 0x65c2d7e8d31C845894491ABe5789Ba1e5d4382fC;
             newAddresses[14] = 0xe1A61d90554131314cB30dB55B8AD4F4b6e21C3a;
             newAddresses[15] = 0xe9F074d003b377A197D336B8a1c86EdaA6cC4dEF;
             newAddresses[16] = 0x3ea519270248BdEE4a939df20049E02290bf9CaF;
@@ -135,12 +135,12 @@ contract SmokeTestStaging is MainnetBaseSetup {
         newAddresses[0] = 0xc5c971e6B9F01dcf06bda896AEA3648eD6e3EFb3;
         newAddresses[1] = 0x2759142A9e3cBbcCc1E3d5F76490eEE4007B8943;
         newAddresses[2] = EMERGENCY_ADMIN;
-        newAddresses[3] = EMERGENCY_ADMIN;
+        newAddresses[3] = 0x65c2d7e8d31C845894491ABe5789Ba1e5d4382fC;
         newAddresses[4] = 0xF1c73958118F22Fc3A3947f405DcEBF08a1E68f7;
         newAddresses[5] = 0x3ea519270248BdEE4a939df20049E02290bf9CaF;
         newAddresses[6] = 0xe1A61d90554131314cB30dB55B8AD4F4b6e21C3a;
         newAddresses[7] = 0xe9F074d003b377A197D336B8a1c86EdaA6cC4dEF;
-        newAddresses[8] = EMERGENCY_ADMIN;
+        newAddresses[8] = 0xaD1bF3301971Ecd9E6219423129e360774ABEA68;
 
         for (uint256 i = 0; i < TARGET_DEPLOYMENT_CHAINS.length; ++i) {
             vm.selectFork(FORKS[TARGET_DEPLOYMENT_CHAINS[i]]);
@@ -148,6 +148,8 @@ contract SmokeTestStaging is MainnetBaseSetup {
 
             for (uint256 j = 0; j < len; ++j) {
                 assert(srbac.hasRole(ids[j], newAddresses[j]));
+                /// @dev each role should have a single member
+                assertEq(srbac.getRoleMemberCount(ids[j]), 1);
             }
             assert(srbac.hasRole(keccak256("PROTOCOL_ADMIN_ROLE"), 0x48aB8AdF869Ba9902Ad483FB1Ca2eFDAb6eabe92));
             assert(srbac.hasRole(keccak256("PROTOCOL_ADMIN_ROLE"), PROTOCOL_ADMINS_STAGING[i]));

--- a/test/mainnet/SmokeTest.t.sol
+++ b/test/mainnet/SmokeTest.t.sol
@@ -44,7 +44,7 @@ contract SmokeTest is MainnetBaseSetup {
         address[] memory newAddresses = new address[](len);
         newAddresses[0] = 0xD911673eAF0D3e15fe662D58De15511c5509bAbB;
         newAddresses[1] = 0x23c658FE050B4eAeB9401768bF5911D11621629c;
-        newAddresses[2] = EMERGENCY_ADMIN;
+        newAddresses[2] = 0x98616F52063d2A301be71386D381F43176A04F0f;
         newAddresses[3] = EMERGENCY_ADMIN;
         newAddresses[4] = 0xaEbb4b9f7e16BEE2a0963569a5E33eE10E478a5f;
         newAddresses[5] = 0x90ed07A867bDb6a73565D7abBc7434Dd810Fafc5;
@@ -105,7 +105,7 @@ contract SmokeTest is MainnetBaseSetup {
             newAddresses[10] = 0xD911673eAF0D3e15fe662D58De15511c5509bAbB;
             newAddresses[11] = 0x23c658FE050B4eAeB9401768bF5911D11621629c;
             newAddresses[12] = 0xaEbb4b9f7e16BEE2a0963569a5E33eE10E478a5f;
-            newAddresses[13] = EMERGENCY_ADMIN;
+            newAddresses[13] = 0x98616F52063d2A301be71386D381F43176A04F0f;
             newAddresses[14] = 0x90ed07A867bDb6a73565D7abBc7434Dd810Fafc5;
             newAddresses[15] = 0x7c9c8C0A9aA5D8a2c2e6C746641117Cc9591296a;
             newAddresses[16] = 0x1666660D2F506e754CB5c8E21BDedC7DdEc6Be1C;
@@ -138,12 +138,12 @@ contract SmokeTest is MainnetBaseSetup {
         newAddresses[0] = 0xD911673eAF0D3e15fe662D58De15511c5509bAbB;
         newAddresses[1] = 0x23c658FE050B4eAeB9401768bF5911D11621629c;
         newAddresses[2] = EMERGENCY_ADMIN;
-        newAddresses[3] = EMERGENCY_ADMIN;
+        newAddresses[3] = 0x98616F52063d2A301be71386D381F43176A04F0f;
         newAddresses[4] = 0xaEbb4b9f7e16BEE2a0963569a5E33eE10E478a5f;
         newAddresses[5] = 0x1666660D2F506e754CB5c8E21BDedC7DdEc6Be1C;
         newAddresses[6] = 0x90ed07A867bDb6a73565D7abBc7434Dd810Fafc5;
         newAddresses[7] = 0x7c9c8C0A9aA5D8a2c2e6C746641117Cc9591296a;
-        newAddresses[8] = EMERGENCY_ADMIN;
+        newAddresses[8] = 0x1A86b5c1467331A3A52572663FDBf037A9e29719;
 
         for (uint256 i = 0; i < TARGET_DEPLOYMENT_CHAINS.length; ++i) {
             vm.selectFork(FORKS[TARGET_DEPLOYMENT_CHAINS[i]]);
@@ -151,6 +151,8 @@ contract SmokeTest is MainnetBaseSetup {
 
             for (uint256 j = 0; j < len; ++j) {
                 assert(srbac.hasRole(ids[j], newAddresses[j]));
+                /// @dev each role should have a single member
+                assertEq(srbac.getRoleMemberCount(ids[j]), 1);
             }
             assert(srbac.hasRole(keccak256("PROTOCOL_ADMIN_ROLE"), PROTOCOL_ADMINS[i]));
             assert(srbac.hasRole(keccak256("EMERGENCY_ADMIN_ROLE"), EMERGENCY_ADMIN));


### PR DESCRIPTION
_Changes:_

This PR amends a change made in mainnet contract to enable Broadcasting roles such that Emergency admin is properly revoked from those roles