### PR TITLE
feat: proposed new payment helper SUP-6371

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ update:; forge update
 build :; FOUNDRY_PROFILE=production forge build
 build-unoptimized :; FOUNDRY_PROFILE=localdev forge build
 build-sizes :; FOUNDRY_PROFILE=default forge build --sizes
-test-vvv   :; forge test -vvvvv --match-contract SDMVW0000TokenInputNoSlippageAMB13Fantom
+test-vvv   :; forge test --match-contract PaymentHelperTest
 ftest   :; forge test
 test-ci :; forge test --no-match-path "test/invariant/**/*.sol"
 coverage :; FOUNDRY_PROFILE=coverage forge coverage --match-path "test/**/*.sol" --report lcov

--- a/script/forge-scripts/Abstract.Deploy.Single.s.sol
+++ b/script/forge-scripts/Abstract.Deploy.Single.s.sol
@@ -1022,9 +1022,11 @@ abstract contract AbstractDeploySingle is Script {
                 2_000_000,
                 /// @dev ackGasCost to move a msg from dst to source
                 10_000,
-                10_000
+                10_000,
+                200_000
             )
         );
+        /// @dev !WARNING - Default value for updateWithdrawGas for now
 
         PaymentHelper(payable(vars.paymentHelper)).updateRegisterAERC20Params(abi.encode(4, abi.encode(0, "")));
 
@@ -1113,7 +1115,7 @@ abstract contract AbstractDeploySingle is Script {
         gasUsed[BASE][3] = abi.encode(600_000);
         gasUsed[FANTOM][3] = abi.encode(600_000);
 
-        // updateGasUsed == 4 (only used on deposits for now)
+        // updateDepositGasUsed == 4 (only used on deposits for now)
         gasUsed[ETH][4] = abi.encode(225_000);
         gasUsed[BSC][4] = abi.encode(225_000);
         gasUsed[AVAX][4] = abi.encode(200_000);
@@ -1183,6 +1185,7 @@ abstract contract AbstractDeploySingle is Script {
 
         /// price feeds on all chains
         mapping(uint64 => mapping(uint64 => address)) storage priceFeeds = PRICE_FEEDS;
+        /// https://docs.chain.link/data-feeds/price-feeds/addresses?network=ethereum&page=1
 
         /// ETH
         priceFeeds[ETH][ETH] = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
@@ -1192,7 +1195,7 @@ abstract contract AbstractDeploySingle is Script {
         priceFeeds[ETH][OP] = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
         priceFeeds[ETH][ARBI] = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
         priceFeeds[ETH][BASE] = 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419;
-        priceFeeds[ETH][FANTOM] = address(0);
+        priceFeeds[ETH][FANTOM] = 0x2DE7E4a9488488e0058B95854CC2f7955B35dC9b;
 
         /// BSC
         priceFeeds[BSC][BSC] = 0x0567F2323251f0Aab15c8dFb1967E4e8A7D42aeE;

--- a/script/forge-scripts/Abstract.Deploy.Single.s.sol
+++ b/script/forge-scripts/Abstract.Deploy.Single.s.sol
@@ -1125,14 +1125,38 @@ abstract contract AbstractDeploySingle is Script {
         gasUsed[BASE][4] = abi.encode(200_000);
         gasUsed[FANTOM][4] = abi.encode(200_000);
 
-        // withdrawGasUsed == 6 (incl. cost to update)
-        gasUsed[ETH][6] = abi.encode(600_000);
-        gasUsed[BSC][6] = abi.encode(1_500_000);
-        gasUsed[AVAX][6] = abi.encode(1_000_000);
-        gasUsed[POLY][6] = abi.encode(1_000_000);
-        gasUsed[OP][6] = abi.encode(1_000_000);
-        gasUsed[ARBI][6] = abi.encode(2_500_000);
-        gasUsed[BASE][6] = abi.encode(1_500_000);
+        // withdrawGasUsed == 6
+        /* Based on
+         these are the values for withdrawal processing gas
+        Arbitrum Median: 2095936.0
+        Arbitrum Mean: 2482432.604688763
+        Arbitrum Mean divided by 1.5: 1654955.0697925087
+        Matic Median: 1250149.0
+        Matic Mean: 1678863.4611848826
+        Matic Mean divided by 1.5: 1119242.3074565884
+        BSC Median: 1115388.5
+        BSC Mean: 1255750.8333333333
+        BSC Mean divided by 1.5: 837167.2222222222
+        Mainnet Median: 1550764.0
+        Mainnet Mean: 1908495.0
+        Mainnet Mean divided by 1.5: 1272330.0
+        Optimism Median: 2116207.0
+        Optimism Mean: 2574219.05440613
+        Optimism Mean divided by 1.5: 1716146.0362707534
+        Avalanche Median: 1212435.0
+        Avalanche Mean: 2241043.0
+        Avalanche Mean divided by 1.5: 1494028.6666666667
+        Base Median: 1238921.0
+        Base Mean: 1768168.27314578
+        Base Mean divided by 1.5: 1178778.8487638533
+        */
+        gasUsed[ETH][6] = abi.encode(1_272_330);
+        gasUsed[BSC][6] = abi.encode(837_167);
+        gasUsed[AVAX][6] = abi.encode(1_494_028);
+        gasUsed[POLY][6] = abi.encode(1_119_242);
+        gasUsed[OP][6] = abi.encode(1_716_146);
+        gasUsed[ARBI][6] = abi.encode(1_654_955);
+        gasUsed[BASE][6] = abi.encode(1_178_778);
         gasUsed[FANTOM][6] = abi.encode(1_500_000);
 
         mapping(uint64 => address) storage lzEndpointsStorage = LZ_ENDPOINTS;

--- a/script/forge-scripts/misc/Abstract.Update.PaymentHelper.s.sol
+++ b/script/forge-scripts/misc/Abstract.Update.PaymentHelper.s.sol
@@ -25,7 +25,7 @@ abstract contract AbstractUpdatePaymentHelper is BatchScript, EnvironmentUtils {
         gasUsed[ARBI][3] = abi.encode(2_500_000);
         gasUsed[BASE][3] = abi.encode(600_000);
 
-        // updateGasUsed == 4 (only used on deposits for now)
+        // updateDepositGasUsed == 4 (only used on deposits for now)
         gasUsed[ETH][4] = abi.encode(225_000);
         gasUsed[BSC][4] = abi.encode(225_000);
         gasUsed[AVAX][4] = abi.encode(200_000);

--- a/src/interfaces/IPaymentHelper.sol
+++ b/src/interfaces/IPaymentHelper.sol
@@ -21,7 +21,7 @@ interface IPaymentHelper {
     /// @param nativeFeedOracle is the native price feed oracle
     /// @param gasPriceOracle is the gas price oracle
     /// @param swapGasUsed is the swap gas params
-    /// @param updateGasUsed is the update gas params
+    /// @param updateDepositGasUsed is the update gas params
     /// @param depositGasUsed is the deposit per vault gas on the chain
     /// @param withdrawGasUsed is the withdraw per vault gas on the chain
     /// @param defaultNativePrice is the native price on the specified chain
@@ -30,11 +30,12 @@ interface IPaymentHelper {
     /// @param ackGasCost is the gas cost for sending and processing from dst->src
     /// @param timelockCost is the extra cost for processing timelocked payloads
     /// @param emergencyCost is the extra cost for processing emergency payloads
+    /// @param updateWithdrawGasUsed is the update gas params for withdraws
     struct PaymentHelperConfig {
         address nativeFeedOracle;
         address gasPriceOracle;
         uint256 swapGasUsed;
-        uint256 updateGasUsed;
+        uint256 updateDepositGasUsed;
         uint256 depositGasUsed;
         uint256 withdrawGasUsed;
         uint256 defaultNativePrice;
@@ -43,6 +44,7 @@ interface IPaymentHelper {
         uint256 ackGasCost;
         uint256 timelockCost;
         uint256 emergencyCost;
+        uint256 updateWithdrawGasUsed;
     }
 
     //////////////////////////////////////////////////////////////
@@ -214,16 +216,43 @@ interface IPaymentHelper {
     //              EXTERNAL WRITE FUNCTIONS                    //
     //////////////////////////////////////////////////////////////
 
-    /// @dev admin can configure a remote chain for first time
+    /// @dev admin can configure a remote chain for the first time
     /// @param chainId_ is the identifier of new chain id
     /// @param config_ is the chain config
     function addRemoteChain(uint64 chainId_, PaymentHelperConfig calldata config_) external;
+
+    /// @dev admin can configure various remote chain for the first time in a single call
+    /// @param chainIds_ is the identifier of new chain id
+    /// @param configs_ is the chain config
+    function addRemoteChains(uint64[] calldata chainIds_, PaymentHelperConfig[] calldata configs_) external;
 
     /// @dev admin can specifically configure/update certain configuration of a remote chain
     /// @param chainId_ is the remote chain's identifier
     /// @param configType_ is the type of config from 1 -> 6
     /// @param config_ is the encoded new configuration
     function updateRemoteChain(uint64 chainId_, uint256 configType_, bytes memory config_) external;
+
+    /// @dev admin can specifically configure/update certain configurations on a single remote chain
+    /// @param chainId_ are the remote chain's identifier
+    /// @param configTypes_ are the type of config from 1 -> 6 for the given chain
+    /// @param configs_ are the encoded new configurations for each config type for the given chain
+    function batchUpdateRemoteChain(
+        uint64 chainId_,
+        uint256[] calldata configTypes_,
+        bytes[] calldata configs_
+    )
+        external;
+
+    /// @dev admin can specifically configure/update certain configurations on various remote chains at the same time
+    /// @param chainIds_ are the remote chain's identifier
+    /// @param configTypes_ are the type of config from 1 -> 6 for each chain
+    /// @param configs_ are the encoded new configurations for each config type and chains
+    function batchUpdateRemoteChains(
+        uint64[] calldata chainIds_,
+        uint256[][] calldata configTypes_,
+        bytes[][] calldata configs_
+    )
+        external;
 
     /// @dev admin updates config for register transmuter amb params
     /// @param extraDataForTransmuter_ is the broadcast extra data

--- a/src/payments/PaymentHelper.sol
+++ b/src/payments/PaymentHelper.sol
@@ -766,6 +766,8 @@ contract PaymentHelper is IPaymentHelper {
     {
         uint256 len = configTypes_.length;
 
+        if (len == 0) revert Error.ZERO_INPUT_VALUE();
+
         if (len != configs_.length) revert Error.ARRAY_LENGTH_MISMATCH();
 
         for (uint256 i; i < len; ++i) {
@@ -784,6 +786,8 @@ contract PaymentHelper is IPaymentHelper {
         onlyEmergencyAdmin
     {
         uint256 len = chainIds_.length;
+
+        if (len == 0) revert Error.ZERO_INPUT_VALUE();
 
         if (!(len == configTypes_.length && len == configs_.length)) revert Error.ARRAY_LENGTH_MISMATCH();
 
@@ -957,10 +961,10 @@ contract PaymentHelper is IPaymentHelper {
         uint256 len = liqRequests_.length;
         for (uint256 i; i < len; i++) {
             /// @dev liqRequests[i].token on withdraws is the desired token
-            /// @dev however if this function is called on source chain we have no way to verify if
-            /// @dev this token is equal to the vault asset. Therefore, summing up the gas for all
-            /// @dev cases where txData is null (requires a destination update)
-            if (liqRequests_[i].txData.length == 0) {
+            /// @dev if token is address(0) -> user wants settlement without any liq data
+            /// @dev this means that if no txData is present and token is different than address(0) an update is
+            /// required in destination
+            if (liqRequests_[i].txData.length == 0 && liqRequests_[i].token != address(0)) {
                 gasUsed += updateWithdrawGasUsed[dstChainId_];
             }
         }

--- a/src/payments/PaymentHelper.sol
+++ b/src/payments/PaymentHelper.sol
@@ -113,9 +113,13 @@ contract PaymentHelper is IPaymentHelper {
         _;
     }
 
-    modifier onlyEmergencyAdmin() {
-        if (!ISuperRBAC(_getAddress(keccak256("SUPER_RBAC"))).hasEmergencyAdminRole(msg.sender)) {
-            revert Error.NOT_EMERGENCY_ADMIN();
+    modifier onlyPaymentAdmin() {
+        if (
+            !ISuperRBAC(superRegistry.getAddress(keccak256("SUPER_RBAC"))).hasRole(
+                keccak256("PAYMENT_ADMIN_ROLE"), msg.sender
+            )
+        ) {
+            revert Error.NOT_PAYMENT_ADMIN();
         }
         _;
     }
@@ -664,7 +668,7 @@ contract PaymentHelper is IPaymentHelper {
     )
         public
         override
-        onlyEmergencyAdmin
+        onlyPaymentAdmin
     {
         /// @dev Type 1: DST TOKEN PRICE FEED ORACLE
         if (configType_ == 1) {
@@ -762,7 +766,7 @@ contract PaymentHelper is IPaymentHelper {
     )
         public
         override
-        onlyEmergencyAdmin
+        onlyPaymentAdmin
     {
         uint256 len = configTypes_.length;
 
@@ -783,7 +787,7 @@ contract PaymentHelper is IPaymentHelper {
     )
         external
         override
-        onlyEmergencyAdmin
+        onlyPaymentAdmin
     {
         uint256 len = chainIds_.length;
 
@@ -797,7 +801,7 @@ contract PaymentHelper is IPaymentHelper {
     }
 
     /// @inheritdoc IPaymentHelper
-    function updateRegisterAERC20Params(bytes memory extraDataForTransmuter_) external onlyEmergencyAdmin {
+    function updateRegisterAERC20Params(bytes memory extraDataForTransmuter_) external onlyPaymentAdmin {
         extraDataForTransmuter = extraDataForTransmuter_;
     }
 

--- a/test/invariant/handlers/VaultSharesHandler.sol
+++ b/test/invariant/handlers/VaultSharesHandler.sol
@@ -372,6 +372,38 @@ contract VaultSharesHandler is InvariantProtocolActions {
         rpcURLs[BASE] = BASE_RPC_URL;
         rpcURLs[FANTOM] = FANTOM_RPC_URL;
 
+        mapping(uint64 => mapping(uint256 => bytes)) storage gasUsed = GAS_USED;
+
+        // swapGasUsed = 3
+        gasUsed[ETH][3] = abi.encode(400_000);
+        gasUsed[BSC][3] = abi.encode(650_000);
+        gasUsed[AVAX][3] = abi.encode(850_000);
+        gasUsed[POLY][3] = abi.encode(700_000);
+        gasUsed[OP][3] = abi.encode(550_000);
+        gasUsed[ARBI][3] = abi.encode(2_500_000);
+        gasUsed[BASE][3] = abi.encode(600_000);
+        gasUsed[FANTOM][3] = abi.encode(600_000);
+
+        // updateDepositGasUsed == 4 (only used on deposits for now)
+        gasUsed[ETH][4] = abi.encode(225_000);
+        gasUsed[BSC][4] = abi.encode(225_000);
+        gasUsed[AVAX][4] = abi.encode(200_000);
+        gasUsed[POLY][4] = abi.encode(200_000);
+        gasUsed[OP][4] = abi.encode(200_000);
+        gasUsed[ARBI][4] = abi.encode(1_400_000);
+        gasUsed[BASE][4] = abi.encode(200_000);
+        gasUsed[FANTOM][4] = abi.encode(200_000);
+
+        // withdrawGasUsed == 6 (incl. cost to update)
+        gasUsed[ETH][6] = abi.encode(600_000);
+        gasUsed[BSC][6] = abi.encode(1_500_000);
+        gasUsed[AVAX][6] = abi.encode(1_000_000);
+        gasUsed[POLY][6] = abi.encode(1_000_000);
+        gasUsed[OP][6] = abi.encode(1_000_000);
+        gasUsed[ARBI][6] = abi.encode(2_500_000);
+        gasUsed[BASE][6] = abi.encode(1_500_000);
+        gasUsed[FANTOM][6] = abi.encode(1_500_000);
+
         mapping(uint64 => address) storage lzEndpointsStorage = LZ_ENDPOINTS;
         lzEndpointsStorage[ETH] = ETH_lzEndpoint;
         lzEndpointsStorage[BSC] = BSC_lzEndpoint;

--- a/test/invariant/handlers/VaultSharesHandler.sol
+++ b/test/invariant/handlers/VaultSharesHandler.sol
@@ -394,14 +394,14 @@ contract VaultSharesHandler is InvariantProtocolActions {
         gasUsed[BASE][4] = abi.encode(200_000);
         gasUsed[FANTOM][4] = abi.encode(200_000);
 
-        // withdrawGasUsed == 6 (incl. cost to update)
-        gasUsed[ETH][6] = abi.encode(600_000);
-        gasUsed[BSC][6] = abi.encode(1_500_000);
-        gasUsed[AVAX][6] = abi.encode(1_000_000);
-        gasUsed[POLY][6] = abi.encode(1_000_000);
-        gasUsed[OP][6] = abi.encode(1_000_000);
-        gasUsed[ARBI][6] = abi.encode(2_500_000);
-        gasUsed[BASE][6] = abi.encode(1_500_000);
+        // withdrawGasUsed == 6
+        gasUsed[ETH][6] = abi.encode(1_272_330);
+        gasUsed[BSC][6] = abi.encode(837_167);
+        gasUsed[AVAX][6] = abi.encode(1_494_028);
+        gasUsed[POLY][6] = abi.encode(1_119_242);
+        gasUsed[OP][6] = abi.encode(1_716_146);
+        gasUsed[ARBI][6] = abi.encode(1_654_955);
+        gasUsed[BASE][6] = abi.encode(1_178_778);
         gasUsed[FANTOM][6] = abi.encode(1_500_000);
 
         mapping(uint64 => address) storage lzEndpointsStorage = LZ_ENDPOINTS;

--- a/test/mainnet/SmokeTest.t.sol
+++ b/test/mainnet/SmokeTest.t.sol
@@ -452,7 +452,7 @@ contract SmokeTest is MainnetBaseSetup {
                         abi.decode(GAS_USED[TARGET_DEPLOYMENT_CHAINS[j]][3], (uint256))
                     );
                     assertEq(
-                        paymentHelper.updateGasUsed(TARGET_DEPLOYMENT_CHAINS[j]),
+                        paymentHelper.updateDepositGasUsed(TARGET_DEPLOYMENT_CHAINS[j]),
                         abi.decode(GAS_USED[TARGET_DEPLOYMENT_CHAINS[j]][4], (uint256))
                     );
 

--- a/test/unit/payments/PaymentHelper.t.sol
+++ b/test/unit/payments/PaymentHelper.t.sol
@@ -1262,6 +1262,36 @@ contract PaymentHelperTest is ProtocolActions {
         vm.stopPrank();
     }
 
+    function test_addRemoteChains_zeroInputLen() public {
+        vm.startPrank(deployer);
+        uint64[] memory chainIds;
+
+        IPaymentHelper.PaymentHelperConfig[] memory configs = new IPaymentHelper.PaymentHelperConfig[](2);
+        configs[0] = IPaymentHelper.PaymentHelperConfig(
+            address(0), address(0), 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432
+        );
+        configs[1] = IPaymentHelper.PaymentHelperConfig(
+            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
+            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
+            422,
+            423,
+            424,
+            425,
+            426,
+            427,
+            428,
+            429,
+            430,
+            431,
+            432
+        );
+
+        vm.expectRevert(Error.ZERO_INPUT_VALUE.selector);
+        paymentHelper.addRemoteChains(chainIds, configs);
+
+        vm.stopPrank();
+    }
+
     function test_updateRemoteChain() public {
         /// chain id used: 420
 

--- a/test/unit/payments/PaymentHelper.t.sol
+++ b/test/unit/payments/PaymentHelper.t.sol
@@ -1099,7 +1099,7 @@ contract PaymentHelperTest is ProtocolActions {
         vm.prank(deployer);
         paymentHelper.updateRemoteChain(1, 4, abi.encode(423));
 
-        uint256 result4 = paymentHelper.updateGasUsed(1);
+        uint256 result4 = paymentHelper.updateDepositGasUsed(1);
         assertEq(result4, 423);
 
         /// set config type: 5
@@ -1156,7 +1156,9 @@ contract PaymentHelperTest is ProtocolActions {
         vm.startPrank(deployer);
         paymentHelper.addRemoteChain(
             420,
-            IPaymentHelper.PaymentHelperConfig(address(0), address(0), 422, 423, 424, 425, 426, 427, 428, 429, 430, 431)
+            IPaymentHelper.PaymentHelperConfig(
+                address(0), address(0), 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432
+            )
         );
 
         paymentHelper.addRemoteChain(
@@ -1173,7 +1175,8 @@ contract PaymentHelperTest is ProtocolActions {
                 428,
                 429,
                 430,
-                431
+                431,
+                432
             )
         );
 
@@ -1183,7 +1186,7 @@ contract PaymentHelperTest is ProtocolActions {
         paymentHelper.addRemoteChain(
             421,
             IPaymentHelper.PaymentHelperConfig(
-                mock, 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431
+                mock, 0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432
             )
         );
 
@@ -1191,7 +1194,7 @@ contract PaymentHelperTest is ProtocolActions {
         paymentHelper.addRemoteChain(
             421,
             IPaymentHelper.PaymentHelperConfig(
-                0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, mock, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431
+                0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419, mock, 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432
             )
         );
 
@@ -1226,7 +1229,7 @@ contract PaymentHelperTest is ProtocolActions {
         vm.prank(deployer);
         paymentHelper.updateRemoteChain(420, 4, abi.encode(423));
 
-        uint256 result4 = paymentHelper.updateGasUsed(420);
+        uint256 result4 = paymentHelper.updateDepositGasUsed(420);
         assertEq(result4, 423);
 
         /// set config type: 5

--- a/test/unit/payments/PaymentHelper.t.sol
+++ b/test/unit/payments/PaymentHelper.t.sol
@@ -1201,6 +1201,67 @@ contract PaymentHelperTest is ProtocolActions {
         vm.stopPrank();
     }
 
+    function test_addRemoteChains() public {
+        vm.startPrank(deployer);
+        uint64[] memory chainIds = new uint64[](2);
+        chainIds[0] = 422;
+        chainIds[1] = 423;
+
+        IPaymentHelper.PaymentHelperConfig[] memory configs = new IPaymentHelper.PaymentHelperConfig[](2);
+        configs[0] = IPaymentHelper.PaymentHelperConfig(
+            address(0), address(0), 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432
+        );
+        configs[1] = IPaymentHelper.PaymentHelperConfig(
+            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
+            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
+            422,
+            423,
+            424,
+            425,
+            426,
+            427,
+            428,
+            429,
+            430,
+            431,
+            432
+        );
+        paymentHelper.addRemoteChains(chainIds, configs);
+
+        vm.stopPrank();
+    }
+
+    function test_addRemoteChains_differentLen() public {
+        vm.startPrank(deployer);
+        uint64[] memory chainIds = new uint64[](1);
+        chainIds[0] = 422;
+
+        IPaymentHelper.PaymentHelperConfig[] memory configs = new IPaymentHelper.PaymentHelperConfig[](2);
+        configs[0] = IPaymentHelper.PaymentHelperConfig(
+            address(0), address(0), 422, 423, 424, 425, 426, 427, 428, 429, 430, 431, 432
+        );
+        configs[1] = IPaymentHelper.PaymentHelperConfig(
+            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
+            0x5f4eC3Df9cbd43714FE2740f5E3616155c5b8419,
+            422,
+            423,
+            424,
+            425,
+            426,
+            427,
+            428,
+            429,
+            430,
+            431,
+            432
+        );
+
+        vm.expectRevert(Error.ARRAY_LENGTH_MISMATCH.selector);
+        paymentHelper.addRemoteChains(chainIds, configs);
+
+        vm.stopPrank();
+    }
+
     function test_updateRemoteChain() public {
         /// chain id used: 420
 
@@ -1287,6 +1348,308 @@ contract PaymentHelperTest is ProtocolActions {
 
         uint256 result12 = paymentHelper.emergencyCost(1);
         assertEq(result12, 431);
+
+        /// set config type: 13
+        vm.prank(deployer);
+        paymentHelper.updateRemoteChain(1, 13, abi.encode(431));
+
+        uint256 result13 = paymentHelper.updateWithdrawGasUsed(1);
+        assertEq(result13, 431);
+    }
+
+    function test_batchUpdateRemoteChain() public {
+        /// chain id used: 420
+        uint256[] memory configTypes = new uint256[](13);
+        configTypes[0] = 1;
+        configTypes[1] = 2;
+        configTypes[2] = 3;
+        configTypes[3] = 4;
+        configTypes[4] = 5;
+        configTypes[5] = 6;
+        configTypes[6] = 7;
+        configTypes[7] = 8;
+        configTypes[8] = 9;
+        configTypes[9] = 10;
+        configTypes[10] = 11;
+        configTypes[11] = 12;
+        configTypes[12] = 13;
+
+        bytes[] memory configs = new bytes[](13);
+        configs[0] = abi.encode(address(mockGasPriceOracle));
+        configs[1] = abi.encode(address(mockGasPriceOracle));
+        configs[2] = abi.encode(422);
+        configs[3] = abi.encode(423);
+        configs[4] = abi.encode(424);
+        configs[5] = abi.encode(425);
+        configs[6] = abi.encode(426);
+        configs[7] = abi.encode(427);
+        configs[8] = abi.encode(428);
+        configs[9] = abi.encode(429);
+        configs[10] = abi.encode(430);
+        configs[11] = abi.encode(431);
+        configs[12] = abi.encode(432);
+
+        vm.prank(deployer);
+        paymentHelper.batchUpdateRemoteChain(420, configTypes, configs);
+
+        address result1 = address(paymentHelper.nativeFeedOracle(420));
+        assertEq(result1, address(mockGasPriceOracle));
+
+        address result2 = address(paymentHelper.gasPriceOracle(420));
+        assertEq(result2, address(mockGasPriceOracle));
+
+        uint256 result3 = paymentHelper.swapGasUsed(420);
+        assertEq(result3, 422);
+
+        uint256 result4 = paymentHelper.updateDepositGasUsed(420);
+        assertEq(result4, 423);
+
+        uint256 result5 = paymentHelper.depositGasUsed(420);
+        assertEq(result5, 424);
+
+        uint256 result6 = paymentHelper.withdrawGasUsed(420);
+        assertEq(result6, 425);
+
+        uint256 result7 = paymentHelper.nativePrice(420);
+        assertEq(result7, 426);
+
+        uint256 result8 = paymentHelper.gasPrice(420);
+        assertEq(result8, 427);
+
+        uint256 result9 = paymentHelper.gasPerByte(420);
+        assertEq(result9, 428);
+
+        uint256 result10 = paymentHelper.ackGasCost(420);
+        assertEq(result10, 429);
+
+        uint256 result11 = paymentHelper.timelockCost(420);
+        assertEq(result11, 430);
+
+        uint256 result12 = paymentHelper.emergencyCost(420);
+        assertEq(result12, 431);
+
+        uint256 result13 = paymentHelper.updateWithdrawGasUsed(420);
+        assertEq(result13, 432);
+    }
+
+    function test_batchUpdateRemoteChain_zeroLen() public {
+        /// chain id used: 420
+        uint256[] memory configTypes;
+        bytes[] memory configs;
+
+        vm.prank(deployer);
+        vm.expectRevert(Error.ZERO_INPUT_VALUE.selector);
+        paymentHelper.batchUpdateRemoteChain(420, configTypes, configs);
+    }
+
+    function test_batchUpdateRemoteChain_invalidLen() public {
+        /// chain id used: 420
+        uint256[] memory configTypes = new uint256[](12);
+        configTypes[0] = 1;
+        configTypes[1] = 2;
+        configTypes[2] = 3;
+        configTypes[3] = 4;
+        configTypes[4] = 5;
+        configTypes[5] = 6;
+        configTypes[6] = 7;
+        configTypes[7] = 8;
+        configTypes[8] = 9;
+        configTypes[9] = 10;
+        configTypes[10] = 11;
+        configTypes[11] = 12;
+
+        bytes[] memory configs = new bytes[](13);
+        configs[0] = abi.encode(address(mockGasPriceOracle));
+        configs[1] = abi.encode(address(mockGasPriceOracle));
+        configs[2] = abi.encode(422);
+        configs[3] = abi.encode(423);
+        configs[4] = abi.encode(424);
+        configs[5] = abi.encode(425);
+        configs[6] = abi.encode(426);
+        configs[7] = abi.encode(427);
+        configs[8] = abi.encode(428);
+        configs[9] = abi.encode(429);
+        configs[10] = abi.encode(430);
+        configs[11] = abi.encode(431);
+        configs[12] = abi.encode(432);
+
+        vm.prank(deployer);
+        vm.expectRevert(Error.ARRAY_LENGTH_MISMATCH.selector);
+        paymentHelper.batchUpdateRemoteChain(420, configTypes, configs);
+    }
+
+    function test_batchUpdateRemoteChains() public {
+        uint64[] memory chainIds = new uint64[](2);
+        chainIds[0] = 422;
+        chainIds[1] = 423;
+
+        uint256[][] memory configTypes = new uint256[][](2);
+
+        /// chain id used: 420
+        uint256[] memory configTypesTemp = new uint256[](13);
+        configTypesTemp[0] = 1;
+        configTypesTemp[1] = 2;
+        configTypesTemp[2] = 3;
+        configTypesTemp[3] = 4;
+        configTypesTemp[4] = 5;
+        configTypesTemp[5] = 6;
+        configTypesTemp[6] = 7;
+        configTypesTemp[7] = 8;
+        configTypesTemp[8] = 9;
+        configTypesTemp[9] = 10;
+        configTypesTemp[10] = 11;
+        configTypesTemp[11] = 12;
+        configTypesTemp[12] = 13;
+
+        configTypes[0] = configTypesTemp;
+        configTypes[1] = configTypesTemp;
+
+        bytes[][] memory configs = new bytes[][](2);
+        bytes[] memory configsTemp = new bytes[](13);
+        configsTemp[0] = abi.encode(address(mockGasPriceOracle));
+        configsTemp[1] = abi.encode(address(mockGasPriceOracle));
+        configsTemp[2] = abi.encode(422);
+        configsTemp[3] = abi.encode(423);
+        configsTemp[4] = abi.encode(424);
+        configsTemp[5] = abi.encode(425);
+        configsTemp[6] = abi.encode(426);
+        configsTemp[7] = abi.encode(427);
+        configsTemp[8] = abi.encode(428);
+        configsTemp[9] = abi.encode(429);
+        configsTemp[10] = abi.encode(430);
+        configsTemp[11] = abi.encode(431);
+        configsTemp[12] = abi.encode(432);
+
+        configs[0] = configsTemp;
+        configs[1] = configsTemp;
+
+        vm.prank(deployer);
+        paymentHelper.batchUpdateRemoteChains(chainIds, configTypes, configs);
+
+        address result1 = address(paymentHelper.nativeFeedOracle(422));
+        assertEq(result1, address(mockGasPriceOracle));
+        result1 = address(paymentHelper.nativeFeedOracle(423));
+        assertEq(result1, address(mockGasPriceOracle));
+
+        address result2 = address(paymentHelper.gasPriceOracle(422));
+        assertEq(result2, address(mockGasPriceOracle));
+        result2 = address(paymentHelper.gasPriceOracle(423));
+        assertEq(result2, address(mockGasPriceOracle));
+
+        uint256 result3 = paymentHelper.swapGasUsed(422);
+        assertEq(result3, 422);
+        result3 = paymentHelper.swapGasUsed(423);
+        assertEq(result3, 422);
+
+        uint256 result4 = paymentHelper.updateDepositGasUsed(422);
+        assertEq(result4, 423);
+        result4 = paymentHelper.updateDepositGasUsed(423);
+        assertEq(result4, 423);
+
+        uint256 result5 = paymentHelper.depositGasUsed(422);
+        assertEq(result5, 424);
+        result5 = paymentHelper.depositGasUsed(423);
+        assertEq(result5, 424);
+
+        uint256 result6 = paymentHelper.withdrawGasUsed(422);
+        assertEq(result6, 425);
+        result6 = paymentHelper.withdrawGasUsed(423);
+        assertEq(result6, 425);
+
+        uint256 result7 = paymentHelper.nativePrice(422);
+        assertEq(result7, 426);
+        result7 = paymentHelper.nativePrice(423);
+        assertEq(result7, 426);
+
+        uint256 result8 = paymentHelper.gasPrice(422);
+        assertEq(result8, 427);
+        result8 = paymentHelper.gasPrice(423);
+        assertEq(result8, 427);
+
+        uint256 result9 = paymentHelper.gasPerByte(422);
+        assertEq(result9, 428);
+        result9 = paymentHelper.gasPerByte(423);
+        assertEq(result9, 428);
+
+        uint256 result10 = paymentHelper.ackGasCost(422);
+        assertEq(result10, 429);
+        result10 = paymentHelper.ackGasCost(423);
+        assertEq(result10, 429);
+
+        uint256 result11 = paymentHelper.timelockCost(422);
+        assertEq(result11, 430);
+        result11 = paymentHelper.timelockCost(423);
+        assertEq(result11, 430);
+
+        uint256 result12 = paymentHelper.emergencyCost(422);
+        assertEq(result12, 431);
+        result12 = paymentHelper.emergencyCost(423);
+        assertEq(result12, 431);
+
+        uint256 result13 = paymentHelper.updateWithdrawGasUsed(422);
+        assertEq(result13, 432);
+        result13 = paymentHelper.updateWithdrawGasUsed(423);
+        assertEq(result13, 432);
+    }
+
+    function test_batchUpdateRemoteChains_invalidLen() public {
+        uint64[] memory chainIds = new uint64[](2);
+        chainIds[0] = 422;
+        chainIds[1] = 423;
+
+        uint256[][] memory configTypes = new uint256[][](2);
+
+        /// chain id used: 420
+        uint256[] memory configTypesTemp = new uint256[](13);
+        configTypesTemp[0] = 1;
+        configTypesTemp[1] = 2;
+        configTypesTemp[2] = 3;
+        configTypesTemp[3] = 4;
+        configTypesTemp[4] = 5;
+        configTypesTemp[5] = 6;
+        configTypesTemp[6] = 7;
+        configTypesTemp[7] = 8;
+        configTypesTemp[8] = 9;
+        configTypesTemp[9] = 10;
+        configTypesTemp[10] = 11;
+        configTypesTemp[11] = 12;
+        configTypesTemp[12] = 13;
+
+        configTypes[0] = configTypesTemp;
+        configTypes[1] = configTypesTemp;
+
+        bytes[][] memory configs = new bytes[][](1);
+        bytes[] memory configsTemp = new bytes[](13);
+        configsTemp[0] = abi.encode(address(mockGasPriceOracle));
+        configsTemp[1] = abi.encode(address(mockGasPriceOracle));
+        configsTemp[2] = abi.encode(422);
+        configsTemp[3] = abi.encode(423);
+        configsTemp[4] = abi.encode(424);
+        configsTemp[5] = abi.encode(425);
+        configsTemp[6] = abi.encode(426);
+        configsTemp[7] = abi.encode(427);
+        configsTemp[8] = abi.encode(428);
+        configsTemp[9] = abi.encode(429);
+        configsTemp[10] = abi.encode(430);
+        configsTemp[11] = abi.encode(431);
+        configsTemp[12] = abi.encode(432);
+
+        configs[0] = configsTemp;
+
+        vm.prank(deployer);
+        vm.expectRevert(Error.ARRAY_LENGTH_MISMATCH.selector);
+        paymentHelper.batchUpdateRemoteChains(chainIds, configTypes, configs);
+    }
+
+    function test_batchUpdateRemoteChains_zeroLen() public {
+        uint64[] memory chainIds;
+        uint256[][] memory configTypes = new uint256[][](2);
+
+        bytes[][] memory configs = new bytes[][](2);
+
+        vm.prank(deployer);
+        vm.expectRevert(Error.ZERO_INPUT_VALUE.selector);
+        paymentHelper.batchUpdateRemoteChains(chainIds, configTypes, configs);
     }
 
     function _generateTimelockSuperformPackWithShift() internal pure returns (uint256 superformId_) {

--- a/test/utils/BaseSetup.sol
+++ b/test/utils/BaseSetup.sol
@@ -1201,13 +1201,13 @@ abstract contract BaseSetup is DSTest, StdInvariant, Test {
         gasUsed[FANTOM][4] = abi.encode(200_000);
 
         // withdrawGasUsed == 6 (incl. cost to update)
-        gasUsed[ETH][6] = abi.encode(600_000);
-        gasUsed[BSC][6] = abi.encode(1_500_000);
-        gasUsed[AVAX][6] = abi.encode(1_000_000);
-        gasUsed[POLY][6] = abi.encode(1_000_000);
-        gasUsed[OP][6] = abi.encode(1_000_000);
-        gasUsed[ARBI][6] = abi.encode(2_500_000);
-        gasUsed[BASE][6] = abi.encode(1_500_000);
+        gasUsed[ETH][6] = abi.encode(1_272_330);
+        gasUsed[BSC][6] = abi.encode(837_167);
+        gasUsed[AVAX][6] = abi.encode(1_494_028);
+        gasUsed[POLY][6] = abi.encode(1_119_242);
+        gasUsed[OP][6] = abi.encode(1_716_146);
+        gasUsed[ARBI][6] = abi.encode(1_654_955);
+        gasUsed[BASE][6] = abi.encode(1_178_778);
         gasUsed[FANTOM][6] = abi.encode(1_500_000);
 
         mapping(uint64 => address) storage lzEndpointsStorage = LZ_ENDPOINTS;

--- a/test/utils/MainnetBaseSetup.sol
+++ b/test/utils/MainnetBaseSetup.sol
@@ -424,7 +424,7 @@ abstract contract MainnetBaseSetup is DSTest, StdInvariant, Test {
         gasUsed[ARBI][3] = abi.encode(2_500_000);
         gasUsed[BASE][3] = abi.encode(600_000);
 
-        // updateGasUsed == 4 (only used on deposits for now)
+        // updateDepositGasUsed == 4 (only used on deposits for now)
         gasUsed[ETH][4] = abi.encode(225_000);
         gasUsed[BSC][4] = abi.encode(225_000);
         gasUsed[AVAX][4] = abi.encode(200_000);


### PR DESCRIPTION
Proposes a new payment helper with:
- Split the updateGasUsed into updateDepositGasUsed and updateWithdrawGasUsed

updateDepositGasUsed largely takes the place of updateGasUsed, only applicable to deposits

if no txData is provided in the payload updateWithdrawGasUsed is not added to the total amount. 

Notice that this requires an update to withdrawGasUsed and the values of updateWithdrawGasUsed

- Configuration batch updates


TBA:
- Tests after confirmation of changes