### PR TITLE
fix: Add revert for invalid rebalance selector

### DIFF
--- a/src/router-plus/SuperformRouterPlusAsync.sol
+++ b/src/router-plus/SuperformRouterPlusAsync.sol
@@ -399,6 +399,8 @@ contract SuperformRouterPlusAsync is ISuperformRouterPlusAsync, BaseSuperformRou
                 IBaseRouter.multiDstMultiVaultDeposit,
                 (MultiDstMultiVaultStateReq(data.rebalanceToAmbIds, data.rebalanceToDstChainIds, multiSuperformData))
             );
+        } else {
+            revert INVALID_REBALANCE_SELECTOR();
         }
 
         _deposit(


### PR DESCRIPTION
## Problem

In the completeCrossChainRebalance() function, there's an if-else block that checks against data.rebalanceSelector. However, if none of the conditions in this block are met, the function continues to execute. The subsequent _deposit call will fail because none of the router function signatures are matched. It would be more gas efficient to fail earlier in this scenario.

## Solution

​Insert a last else in the if-else block:

else {
    revert INVALID_REBALANCE_SELECTOR();
}
