### PR TITLE
fix: insert tolerance into `redeemShare()` checks [SUP-8853]

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ build-sizes: ## Builds the project and shows sizes
 
 .PHONY: test-vvv
 test-vvv: ## Runs tests with verbose output
-	forge test --match-contract SuperformRouterPlusTest --evm-version cancun -vvv
+	forge test --match-contract SDMVW0TokenInputNoSlippageAMB1323 --evm-version cancun -vvv
 
 .PHONY: ftest
 ftest: ## Runs tests with cancun evm version

--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ build-sizes: ## Builds the project and shows sizes
 
 .PHONY: test-vvv
 test-vvv: ## Runs tests with verbose output
-	forge test --match-contract SDMVW0TokenInputNoSlippageAMB1323 --evm-version cancun -vvv
+	forge test --match-contract SuperformRouterPlusTest --evm-version cancun -vvv
 
 .PHONY: ftest
 ftest: ## Runs tests with cancun evm version

--- a/src/interfaces/ISuperformRouterPlus.sol
+++ b/src/interfaces/ISuperformRouterPlus.sol
@@ -49,6 +49,9 @@ interface ISuperformRouterPlus is IBaseSuperformRouterPlus {
     /// @notice thrown if the amount of assets received is lower than the slippage
     error ASSETS_RECEIVED_OUT_OF_SLIPPAGE();
 
+    /// @notice thrown if the tolerance is exceeded during shares redemption
+    error TOLERANCE_EXCEEDED();
+
     //////////////////////////////////////////////////////////////
     //                       EVENTS                             //
     //////////////////////////////////////////////////////////////

--- a/src/router-plus/SuperformRouterPlus.sol
+++ b/src/router-plus/SuperformRouterPlus.sol
@@ -521,11 +521,11 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
         uint256 assetsBalanceAfter = asset.balanceOf(address(this));
         balanceDifference = assetsBalanceAfter - assetsBalanceBefore;
 
-        if (assets < TOLERANCE_CONSTANT) revert TOLERANCE_EXCEEDED();
+        if (assets < TOLERANCE_CONSTANT || balanceDifference < TOLERANCE_CONSTANT) revert TOLERANCE_EXCEEDED();
 
         /// @dev validate the slippage
         if (
-            (balanceDifference < assets - TOLERANCE_CONSTANT)
+            (balanceDifference != assets)
                 || (ENTIRE_SLIPPAGE * assets < ((expectedOutputAmount_ * (ENTIRE_SLIPPAGE - maxSlippage_))))
         ) {
             revert ASSETS_RECEIVED_OUT_OF_SLIPPAGE();

--- a/src/router-plus/SuperformRouterPlus.sol
+++ b/src/router-plus/SuperformRouterPlus.sol
@@ -27,6 +27,9 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
 
     uint256 public ROUTER_PLUS_PAYLOAD_ID;
 
+    /// @dev Tolerance constant to account for tokens with rounding issues on transfer
+    uint256 constant TOLERANCE_CONSTANT = 2 wei;
+
     //////////////////////////////////////////////////////////////
     //                      CONSTRUCTOR                         //
     //////////////////////////////////////////////////////////////
@@ -521,6 +524,7 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
         if (
             (balanceDifference != assets)
                 || (ENTIRE_SLIPPAGE * assets < ((expectedOutputAmount_ * (ENTIRE_SLIPPAGE - maxSlippage_))))
+                || (assets - TOLERANCE_CONSTANT > balanceDifference)
         ) {
             revert ASSETS_RECEIVED_OUT_OF_SLIPPAGE();
         }

--- a/src/router-plus/SuperformRouterPlus.sol
+++ b/src/router-plus/SuperformRouterPlus.sol
@@ -521,15 +521,14 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
         uint256 assetsBalanceAfter = asset.balanceOf(address(this));
         balanceDifference = assetsBalanceAfter - assetsBalanceBefore;
 
+        if (assets < TOLERANCE_CONSTANT) revert Error.ZERO_AMOUNT();
+
+        /// @dev validate the slippage
         if (
-            (balanceDifference != assets)
+            (balanceDifference < assets - TOLERANCE_CONSTANT)
                 || (ENTIRE_SLIPPAGE * assets < ((expectedOutputAmount_ * (ENTIRE_SLIPPAGE - maxSlippage_))))
         ) {
             revert ASSETS_RECEIVED_OUT_OF_SLIPPAGE();
-        }
-
-        if ((assets - TOLERANCE_CONSTANT > balanceDifference)) {
-            revert TOLERANCE_EXCEEDED();
         }
     }
 

--- a/src/router-plus/SuperformRouterPlus.sol
+++ b/src/router-plus/SuperformRouterPlus.sol
@@ -28,7 +28,7 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
     uint256 public ROUTER_PLUS_PAYLOAD_ID;
 
     /// @dev Tolerance constant to account for tokens with rounding issues on transfer
-    uint256 constant TOLERANCE_CONSTANT = 2 wei;
+    uint256 constant TOLERANCE_CONSTANT = 10 wei;
 
     //////////////////////////////////////////////////////////////
     //                      CONSTRUCTOR                         //
@@ -524,9 +524,12 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
         if (
             (balanceDifference != assets)
                 || (ENTIRE_SLIPPAGE * assets < ((expectedOutputAmount_ * (ENTIRE_SLIPPAGE - maxSlippage_))))
-                || (assets - TOLERANCE_CONSTANT > balanceDifference)
         ) {
             revert ASSETS_RECEIVED_OUT_OF_SLIPPAGE();
+        }
+
+        if ((assets - TOLERANCE_CONSTANT > balanceDifference)) {
+            revert TOLERANCE_EXCEEDED();
         }
     }
 

--- a/src/router-plus/SuperformRouterPlus.sol
+++ b/src/router-plus/SuperformRouterPlus.sol
@@ -521,6 +521,7 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
         uint256 assetsBalanceAfter = asset.balanceOf(address(this));
         balanceDifference = assetsBalanceAfter - assetsBalanceBefore;
 
+        /// @dev validate the tolerance
         if (assets < TOLERANCE_CONSTANT || balanceDifference < TOLERANCE_CONSTANT) revert TOLERANCE_EXCEEDED();
 
         /// @dev validate the slippage

--- a/src/router-plus/SuperformRouterPlus.sol
+++ b/src/router-plus/SuperformRouterPlus.sol
@@ -521,7 +521,7 @@ contract SuperformRouterPlus is ISuperformRouterPlus, BaseSuperformRouterPlus {
         uint256 assetsBalanceAfter = asset.balanceOf(address(this));
         balanceDifference = assetsBalanceAfter - assetsBalanceBefore;
 
-        if (assets < TOLERANCE_CONSTANT) revert Error.ZERO_AMOUNT();
+        if (assets < TOLERANCE_CONSTANT) revert TOLERANCE_EXCEEDED();
 
         /// @dev validate the slippage
         if (

--- a/test/unit/router-plus/SuperformRouterPlus.t.sol
+++ b/test/unit/router-plus/SuperformRouterPlus.t.sol
@@ -568,11 +568,11 @@ contract SuperformRouterPlusTest is ProtocolActions {
         MockERC20(getContract(SOURCE_CHAIN, "DAI")).approve(address(mockVault), daiAmount);
         uint256 vaultTokenAmount = mockVault.deposit(daiAmount, deployer);
 
-        // Mock the balanceOf function to return a value less than expected
+        // Mock the redeem function to return a value less than expected
         vm.mockCall(
-            address(deployer),
-            abi.encodeWithSelector(IERC4626.maxDeposit.selector, address(mockVault)),
-            abi.encode(daiAmount - 15 wei) // Return half of the expected amount
+            address(mockVault),
+            abi.encodeWithSelector(IERC4626.redeem.selector, vaultTokenAmount, ROUTER_PLUS_SOURCE, ROUTER_PLUS_SOURCE),
+            abi.encode(1) // Return 1 wei
         );
 
         // Prepare deposit4626 args


### PR DESCRIPTION
https://github.com/yAudit/superform-report/issues/2

deposit4626() is used to redeem vault assets and deposit them in a superform vault. However, in _redeemShare(), there is a strict equality balance check, that, in case of stETH, will always revert.

Technical Details

Lido stETH has a know rounding down problem as stated in their [docs](https://docs.lido.fi/guides/lido-tokens-integration-guide/#1-2-wei-corner-case). When trying to redeem stETH with [deposit4626()](https://github.com/superform-xyz/superform-core/blob/f7f06d763a6af148899e9c292f1a57414db60cc3/src/router-plus/SuperformRouterPlus.sol#L356-L390), the [balance check](https://github.com/superform-xyz/superform-core/blob/f7f06d763a6af148899e9c292f1a57414db60cc3/src/router-plus/SuperformRouterPlus.sol#L522) will always fail leading the function to revert.

Impact

Low. It is not possible to use deposit4626() with a stETH vault and any other token that have a similar behaviour.

Recommendation

Avoid to use strict equality and insert a tolerance in the balance check to handle the 1-2 wei corner case in the same way that is done [here](https://github.com/superform-xyz/superform-core/blob/f7f06d763a6af148899e9c292f1a57414db60cc3/src/forms/ERC5115Form.sol#L30-L31).