### PR TITLE
fix: add sanity check for `intertimAsset == 0` in `approveRefund()` [sup 9337]

### DIFF
--- a/src/router-plus/SuperformRouterPlusAsync.sol
+++ b/src/router-plus/SuperformRouterPlusAsync.sol
@@ -450,6 +450,8 @@ contract SuperformRouterPlusAsync is ISuperformRouterPlusAsync, BaseSuperformRou
 
         Refund memory r = refunds[routerPlusPayloadId_];
 
+        if (r.interimToken == address(0)) revert INVALID_REFUND_DATA();
+
         approvedRefund[routerPlusPayloadId_] = true;
 
         /// @dev deleting to prevent re-entrancy

--- a/test/unit/router-plus/SuperformRouterPlus.t.sol
+++ b/test/unit/router-plus/SuperformRouterPlus.t.sol
@@ -2502,6 +2502,16 @@ contract SuperformRouterPlusTest is ProtocolActions {
         SuperformRouterPlusAsync(ROUTER_PLUS_ASYNC_SOURCE).approveRefund(1);
         vm.stopPrank();
 
+        /// @dev testing invalid refund data
+        vm.startPrank(address(1234));
+        SuperformRouterPlusAsync(ROUTER_PLUS_ASYNC_SOURCE).requestRefund(3, 100);
+        vm.stopPrank();
+
+        vm.startPrank(deployer);
+        vm.expectRevert(ISuperformRouterPlusAsync.INVALID_REFUND_DATA.selector);
+        SuperformRouterPlusAsync(ROUTER_PLUS_ASYNC_SOURCE).approveRefund(3);
+        vm.stopPrank();
+
         /// @dev testing valid refund approval
         uint256 balanceBefore = MockERC20(refundToken).balanceOf(deployer);
         uint256 routerBalanceBefore = MockERC20(refundToken).balanceOf(address(ROUTER_PLUS_ASYNC_SOURCE));

--- a/test/unit/router-plus/SuperformRouterPlus.t.sol
+++ b/test/unit/router-plus/SuperformRouterPlus.t.sol
@@ -2503,10 +2503,6 @@ contract SuperformRouterPlusTest is ProtocolActions {
         vm.stopPrank();
 
         /// @dev testing invalid refund data
-        vm.startPrank(address(1234));
-        SuperformRouterPlusAsync(ROUTER_PLUS_ASYNC_SOURCE).requestRefund(3, 100);
-        vm.stopPrank();
-
         vm.startPrank(deployer);
         vm.expectRevert(ISuperformRouterPlusAsync.INVALID_REFUND_DATA.selector);
         SuperformRouterPlusAsync(ROUTER_PLUS_ASYNC_SOURCE).approveRefund(3);


### PR DESCRIPTION
Add `if (r.interimToken == address(0)) revert INVALID_REFUND_DATA();` to `approveRefund()` to prevent approval of refunds that have not yet been requested and add test for this case. 